### PR TITLE
Support for missing Version field in response from server 

### DIFF
--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -78,8 +78,11 @@ namespace io.harness.cfsdk.client.api
         {
             Log.Information("Stopping PollingProcessor");
             // stop timer
-            pollTimer.Dispose();
-            pollTimer = null;
+            if (pollTimer != null)
+            {
+                pollTimer.Dispose();
+                pollTimer = null;
+            }
 
         }
         private void ProcessFlags()

--- a/client/api/Repository.cs
+++ b/client/api/Repository.cs
@@ -140,7 +140,9 @@ namespace io.harness.cfsdk.client.api
         void IRepository.SetFlag(string identifier, FeatureConfig featureConfig)
         {
             FeatureConfig current = GetFlag(identifier, false);
-            if( current != null && current.Version >= featureConfig.Version )
+            // Update stored value in case if server returned newer version,
+            // or if version is equal 0 (or doesn't exist)
+            if( current != null && featureConfig.Version != 0 && current.Version >= featureConfig.Version )
             {
                 Log.Debug($"Flag {identifier} already exists");
                 return;
@@ -156,7 +158,9 @@ namespace io.harness.cfsdk.client.api
         void IRepository.SetSegment(string identifier, Segment segment)
         {
             Segment current = GetSegment(identifier, false);
-            if (current != null && current.Version >= segment.Version)
+            // Update stored value in case if server returned newer version,
+            // or if version is equal 0 (or doesn't exist)
+            if (current != null && segment.Version != 0 && current.Version >= segment.Version)
             {
                 Log.Debug($"Segment {identifier} already exists");
                 return;

--- a/client/cache/FileMapStore.cs
+++ b/client/cache/FileMapStore.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Collections.Generic;
 using io.harness.cfsdk.client.cache;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Serilog;
 
 namespace io.harness.cfsdk.client.api
 {
@@ -39,8 +41,9 @@ namespace io.harness.cfsdk.client.api
                 }
                 return null;
             }
-            catch
+            catch( Exception ex)
             {
+                Log.Error("Failure to deserialize data from file storage", ex);
                 return null;
             }
         }
@@ -52,8 +55,33 @@ namespace io.harness.cfsdk.client.api
 
         public void Set(string key, object value)
         {
-            var str = JsonConvert.SerializeObject(value);
+            var str = JsonConvert.SerializeObject(value, Formatting.Indented, new JsonSerializerSettings {
+                ContractResolver = new IncludeNullPropertiesContractResolver()
+            });
             File.WriteAllText(Path.Combine(storeName, key), str);
         }
+    }
+}
+
+class IncludeNullPropertiesContractResolver : DefaultContractResolver
+{
+    /*
+     * NOTE: When property has Required = AllowNull and NullValueHandling = Ignore atributes, 
+     * in case of null value property, based on NullValueHandling.Ignore atribute, serialization will create string without property.
+     * In that case deserialization will throw exception as value doesn't exist and requred field is AllowNull (internals of Newtonsoft.json library).
+     * IncludeNullPropertiesContractResolver will be used as custom Contract Resolver, which will enforce all properties that allo null, 
+     * to include null values in serialized output.
+     */
+    protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+    {
+        var properties = base.CreateProperties(type, memberSerialization);
+        foreach (var p in properties)
+        {
+            if (p.Required == Required.AllowNull)
+            {
+                p.NullValueHandling = NullValueHandling.Include;
+            }
+        }
+        return properties;
     }
 }

--- a/tests/ff-server-sdk-test/VersionTest.cs
+++ b/tests/ff-server-sdk-test/VersionTest.cs
@@ -51,10 +51,12 @@ namespace ff_server_sdk_test
         }
 
         [Test, Category("Version Testing")]
-        public async Task TestVersion()
+        public void TestVersionProperty()
         {
 
             // 1. Version from cache/storage should be the same as on "server"
+
+            Thread.Sleep(500);
 
             Segment storedSegment = GetSegment();
 
@@ -91,10 +93,10 @@ namespace ff_server_sdk_test
             Assert.IsTrue(remoteSegment.Name != storedSegment.Name);
             Assert.IsTrue(remoteSegment.Version != storedSegment.Version);
 
-            // 4. Changes are applied with server has 0 for Version or if Version doesn't exist
+            // 4. Changes are applied when server responce has 0 for Version or if Version doesn't exist
 
             remoteSegment.Version = 0;
-            remoteSegment.Name = "accept_change_because_version_0";
+            remoteSegment.Name = "accept_change_because_0_version";
 
             SaveSegment(remoteSegment);
 

--- a/tests/ff-server-sdk-test/VersionTest.cs
+++ b/tests/ff-server-sdk-test/VersionTest.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using io.harness.cfsdk.client.api;
+using io.harness.cfsdk.client.cache;
+using io.harness.cfsdk.client.connector;
+using io.harness.cfsdk.client.dto;
+using io.harness.cfsdk.HarnessOpenAPIService;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace ff_server_sdk_test
+{
+    public class VersionTest
+    {
+        static ICfClient client;
+        static FileMapStore fileMapStore;
+        static Segment remoteSegment;
+        [SetUp]
+        public async Task SetUp()
+        {
+
+            fileMapStore = new FileMapStore("local_storage");
+
+            client = new CfClient(
+                new LocalConnector("local_connector"),
+                Config.Builder().SetStore(fileMapStore).Build());
+
+            remoteSegment = new Segment
+            {
+                Identifier = "test_segment_identifier",
+                Name = "test_segment_name",
+                Rules = Array.Empty<Clause>()
+            };
+
+            SaveSegment(remoteSegment);
+
+            await client.InitializeAndWait();
+        }
+
+        private void SaveSegment(Segment seg)
+        {
+            File.WriteAllText(Path.Combine("local_connector", "segments", "test_segment_identifier.json"), JsonConvert.SerializeObject(seg));
+        }
+
+        private Segment GetSegment()
+        {
+            return fileMapStore.Get("segments_test_segment_identifier", typeof(Segment)) as Segment;
+        }
+
+        [Test, Category("Version Testing")]
+        public async Task TestVersion()
+        {
+
+            // 1. Version from cache/storage should be the same as on "server"
+
+            Segment storedSegment = GetSegment();
+
+            Assert.IsTrue(remoteSegment.Identifier == storedSegment.Identifier);
+            Assert.IsTrue(remoteSegment.Name == storedSegment.Name);
+
+            // 2. Storage and cache should be updated when serving content with higher Version
+
+            remoteSegment.Version = 2;
+            remoteSegment.Name = "updated_name";
+
+            SaveSegment(remoteSegment);
+
+            Thread.Sleep(500);
+
+            storedSegment = GetSegment();
+
+            Assert.IsTrue(remoteSegment.Identifier == storedSegment.Identifier);
+            Assert.IsTrue(remoteSegment.Name == storedSegment.Name);
+            Assert.IsTrue(remoteSegment.Version == storedSegment.Version);
+
+            // 3. Changes are ignored when we have lower version returned from server
+
+            remoteSegment.Version = 1;
+            remoteSegment.Name = "ignore_lower_version";
+
+            SaveSegment(remoteSegment);
+
+            Thread.Sleep(500);
+
+            storedSegment = GetSegment();
+
+            Assert.IsTrue(remoteSegment.Identifier == storedSegment.Identifier);
+            Assert.IsTrue(remoteSegment.Name != storedSegment.Name);
+            Assert.IsTrue(remoteSegment.Version != storedSegment.Version);
+
+            // 4. Changes are applied with server has 0 for Version or if Version doesn't exist
+
+            remoteSegment.Version = 0;
+            remoteSegment.Name = "accept_change_because_version_0";
+
+            SaveSegment(remoteSegment);
+
+            Thread.Sleep(500);
+
+            storedSegment = GetSegment();
+
+            Assert.IsTrue(remoteSegment.Identifier == storedSegment.Identifier);
+            Assert.IsTrue(remoteSegment.Name == storedSegment.Name);
+            Assert.IsTrue(remoteSegment.Version == storedSegment.Version);
+
+        }
+    }
+}


### PR DESCRIPTION
- In case if Version field is missing or is equal to 0, always use content from server.
- Update for Local storage serialization and deserialization based on Newtonsoft library internal processing.
- Unit test update.