### PR TITLE
MAINT - Update package naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To follow along with our test code sample, make sure you’ve:
 ### Install the SDK
 Add the sdk using dotnet
 ```bash
-dotnet add package ff-netF48-server-sdk
+dotnet add package ff-dotnet-server-sdk
 ```
 
 ### Code Sample

--- a/examples/getting_started/getting_started.csproj
+++ b/examples/getting_started/getting_started.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ff-netF48-server-sdk" Version="1.1.3" />
+    <PackageReference Include="ff-dotnet-server-sdk" Version="1.1.3" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <PackageId>ff-dotnet-server-sdk</PackageId>
     <RootNamespace>io.harness.cfsdk</RootNamespace>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Version>1.1.3</Version>


### PR DESCRIPTION
**What**
https://www.nuget.org/packages/ff-dotnet-server-sdk

Updates the package name 
from ff-netF48-server-sdk
to ff-dotnet-server-sdk
Updates readmen to reflect this

**Why**
Issues with publishing SDK Nuget packages, also just generally looks better