### PR TITLE
(FFM-4463) Update parser validation

### DIFF
--- a/Connected Services/HarnessOpenAPIService/HarnessOpenAPIS.cs
+++ b/Connected Services/HarnessOpenAPIService/HarnessOpenAPIS.cs
@@ -1285,7 +1285,7 @@ namespace io.harness.cfsdk.HarnessOpenAPIService
         [Newtonsoft.Json.JsonProperty("prerequisites", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Prerequisite> Prerequisites { get; set; }
     
-        [Newtonsoft.Json.JsonProperty("variationToTargetMap", Required = Newtonsoft.Json.Required.AllowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("variationToTargetMap", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<VariationMap> VariationToTargetMap { get; set; }
     
         [Newtonsoft.Json.JsonProperty("version", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -1352,7 +1352,7 @@ namespace io.harness.cfsdk.HarnessOpenAPIService
         public System.Collections.Generic.ICollection<Target> Excluded { get; set; }
     
         /// <summary>An array of rules that can cause a user to be included in this segment.</summary>
-        [Newtonsoft.Json.JsonProperty("rules", Required = Newtonsoft.Json.Required.AllowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("rules", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<Clause> Rules { get; set; }
     
         [Newtonsoft.Json.JsonProperty("createdAt", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]


### PR DESCRIPTION
**Issue**
Tylertech experienced an issue using the .NET sdk with ff-proxy where if they had a target group with no rules configured the .NET sdk would fail to parse the target groups from the http response during initialisation and error out.
We also previously had this issue from Sharp Gaming if the feature variationToTargetMap was empty.

After digging into this issue I noticed that both of these problem fields were the only properties in our generated spec annotated with  `DisallowNull ` instead of `AllowNull`. The behaviour of these two properties are described [here](https://www.newtonsoft.com/json/help/html/t_newtonsoft_json_required.htm):
**AllowNull:** The property must be defined in JSON but can be a null value.
**DisallowNull:** The property is not required but it cannot be a null value.
Hence the reason it failed to parse was because the proxy didn't send these properties (which is the correct behaviour)

**Solution**
My plan was to install nswag and play around with the code generation properties until I could get these two fields to also generate as `DisallowNull` fields. However after just running nswag with the current config I noticed it auto changed them to `DisallowNull ` fields anyway, so they must have been manually edited when these generated files were first committed.

**Testing**
Tested against ff-proxy and it solves the issue the customer was seeing
Tested against saas and behaviour is still correct