### PR TITLE
(FFM-4835) Debug logging for analytics

### DIFF
--- a/client/api/analytics/AnalyticsEventHandler.cs
+++ b/client/api/analytics/AnalyticsEventHandler.cs
@@ -34,10 +34,6 @@ namespace io.harness.cfsdk.client.api.analytics
                     }
                     break;
                 case EventType.METRICS:
-                    Log.Debug(
-                        "Analytics object received in queue: Target:{@id}, analytics:{@a}",
-                        analytics.Target.Identifier,
-                        analytics);
                     int count = analyticsCache.getIfPresent(analytics);
                     analyticsCache.Put(analytics, count + 1);
                     break;

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -52,6 +52,7 @@ namespace io.harness.cfsdk.client.api.analytics
                     if ((metrics.MetricsData != null && metrics.MetricsData.Count >0)
                         || (metrics.TargetData != null && metrics.TargetData.Count > 0))
                     {
+                        Log.Debug("Sending analytics data :{@a}", metrics);
                         connector.PostMetrics(metrics);
                     }
 


### PR DESCRIPTION
**Changes**
Updating the analytics debug logging. 
Logging every time a metric was added is incredibly noisy and not that accurate because it doesn't give you an indication of what actually gets sent to the /metrics endpoint at the end.
Replaced it with a log where we dump the analytics object before sending the metrics request. This will let us and customers debug what is being sent and why targets may not be being added. 