### PR TITLE
FFM-6877 - Dropped SSE connections are not being detected

### DIFF
--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -85,10 +85,12 @@ namespace io.harness.cfsdk.client.api
 
         public void OnStreamConnected()
         {
+            Log.Debug("Stream connected");
             this.polling.Stop();
         }
         public void OnStreamDisconnected()
         {
+            Log.Debug("Stream disconnected");
             this.polling.Start();
         }
         #endregion

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -56,7 +56,7 @@ namespace io.harness.cfsdk.client.connector
             client.BaseAddress = new Uri(config.ConfigUrl.EndsWith("/") ? config.ConfigUrl : config.ConfigUrl + "/" );
             client.DefaultRequestHeaders.Add("API-Key", apiKey);
             client.DefaultRequestHeaders.Add("Accept", "text /event-stream");
-            client.Timeout = Timeout.InfiniteTimeSpan;
+            client.Timeout = TimeSpan.FromMinutes(1);
             return client;
         }
         

--- a/examples/getting_started/getting_started.csproj
+++ b/examples/getting_started/getting_started.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ff-dotnet-server-sdk" Version="1.1.3" />
+    <PackageReference Include="ff-dotnet-server-sdk" Version="1.1.7" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -5,11 +5,11 @@
     <PackageId>ff-dotnet-server-sdk</PackageId>
     <RootNamespace>io.harness.cfsdk</RootNamespace>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.1.6</Version>
+    <Version>1.1.7</Version>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.1.6</PackageVersion>
+    <PackageVersion>1.1.7</PackageVersion>
     <Authors>support@harness.io</Authors>
-    <Copyright>Copyright © 2022 </Copyright>
+    <Copyright>Copyright © 2023 </Copyright>
     <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/drone/ff-dotnet-server-sdk/blob/main/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/tests/ff-server-sdk-test/connector/EventSourceTest.cs
+++ b/tests/ff-server-sdk-test/connector/EventSourceTest.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using io.harness.cfsdk.client.api;
+using io.harness.cfsdk.client.connector;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using NUnit.Framework.Internal.Execution;
+using Serilog;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+using Serilog;
+using WireMock.Logging;
+using WireMock.Settings;
+
+namespace ff_server_sdk_test.connector
+{
+    [TestFixture]
+    public class EventSourceTest
+    {
+
+        private WireMockServer server;
+
+        [SetUp]
+        public void StartMockServer()
+        {
+            server = WireMockServer.Start(new WireMockServerSettings
+            {
+                Logger = new WireMockConsoleLogger(),
+                ThrowExceptionWhenMatcherFails = true
+            });
+
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.Console()
+                .CreateLogger();
+            
+        }
+
+        [TearDown]
+        public void StopMockServer()
+        {
+            server.Stop();
+        }
+
+        class TestCallback : IUpdateCallback
+        {
+            public int UpdateCount { get; set; }
+            public int ConnectCount { get; set; }
+            public int DisconnectCount { get; set; }
+
+            public List<Message> Events { get; set; } = new();
+
+            private CountdownEvent disconnectLatch = new CountdownEvent(1);
+
+            public void Update(Message message, bool manual)
+            {
+                Log.Information($"Test got stream update, domain={message.Domain} id={message.Identifier} event={message.Event} ver={message.Version} ");
+                Events.Add(message);
+                UpdateCount++;
+            }
+
+            public void OnStreamConnected()
+            {
+                Log.Information("Stream connected");
+                ConnectCount++;
+            }
+
+            public void OnStreamDisconnected()
+            {
+                Log.Information("Stream disconnected");
+                DisconnectCount++;
+                disconnectLatch.Signal();
+            }
+
+            public void WaitForDisconnect()
+            {
+                disconnectLatch.Wait(TimeSpan.FromMinutes(2));
+            }
+        }
+
+        [Test]
+        public void ShouldParseEventsCorrectly()
+        {
+            server
+                .Given(Request.Create().WithPath("/api/1.0/stream").UsingGet())
+                .RespondWith(
+                    Response.Create()
+                        .WithStatusCode(200)
+                        .WithBody(@"data: { ""domain"": ""flag"",  ""event"": ""patch"",  ""identifier"": ""flagid"",  ""version"": ""0""}, 
+                                    data: { ""domain"": ""flag"",  ""event"": ""patch"",  ""identifier"": ""flagid"",  ""version"": ""1""}
+                                    ")
+                );
+
+            var callback = new TestCallback();
+            Config config = new ConfigBuilder().ConfigUrl(server.Url + "/api/1.0").Build();
+            var httpClient = SseHttpClient(config, "dummyapikey");
+            var eventSource = new EventSource(httpClient, "stream", config, callback);
+            eventSource.Start();
+
+            callback.WaitForDisconnect();
+
+            Assert.That(callback.ConnectCount, Is.EqualTo(1));
+            Assert.That(callback.UpdateCount, Is.EqualTo(2));
+            Assert.That(callback.DisconnectCount, Is.EqualTo(1));
+
+            for (int i = 0; i < 2; i++)
+            {
+                Assert.That(callback.Events[i].Event, Is.EqualTo("patch"));
+                Assert.That(callback.Events[i].Domain, Is.EqualTo("flag"));
+                Assert.That(callback.Events[i].Identifier, Is.EqualTo("flagid"));
+                Assert.That(callback.Events[i].Version, Is.EqualTo(i));
+            }
+        }
+        
+        [Test]
+        public void ShouldNotHangWhenStreamIsDisconnected()
+        {
+            server
+                .Given(Request.Create().WithPath("/api/1.0/stream").UsingGet())
+                .RespondWith(
+                    Response.Create()
+                        .WithStatusCode(200)
+                        .WithBody(@"data: { ""domain"": ""flag"",  ""event"": ""patch"",  ""identifier"": ""flagid"",  ""version"": ""0""}, 
+                                    data: { ""domain"": ""flag"",  ""event"": ""patch"",  ""identifier"": ""flagid"",  ""version"": ""1""}
+                                    ")
+                        
+                );
+
+            server
+                .Given(Request.Create().WithPath("/api/1.0/stream").UsingGet())
+                .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithFault(FaultType.MALFORMED_RESPONSE_CHUNK));
+
+            var callback = new TestCallback();
+            Config config = new ConfigBuilder().ConfigUrl(server.Url + "/api/1.0").Build();
+            var httpClient = SseHttpClient(config, "dummyapikey");
+            var eventSource = new EventSource(httpClient, "stream", config, callback);
+            eventSource.Start();
+
+            callback.WaitForDisconnect();
+
+            Assert.That(callback.ConnectCount, Is.EqualTo(1));
+            Assert.That(callback.UpdateCount, Is.EqualTo(0));
+            Assert.That(callback.DisconnectCount, Is.EqualTo(1));
+        }
+
+        private static HttpClient SseHttpClient(Config config, string apiKey)
+        {
+            HttpClient client = new HttpClient();
+            client.BaseAddress = new Uri(config.ConfigUrl.EndsWith("/") ? config.ConfigUrl : config.ConfigUrl + "/" );
+            client.DefaultRequestHeaders.Add("API-Key", apiKey);
+            client.DefaultRequestHeaders.Add("Accept", "text /event-stream");
+            client.Timeout = TimeSpan.FromMinutes(1);
+            return client;
+        }
+    }
+}

--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -20,6 +20,9 @@
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="WireMock.Net" Version="1.5.16" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
FFM-6877 - Dropped SSE connections are not being detected

What
SSE EventSource does not detect that a connection may have dropped. This update removes calls to StreamReader's EndOfStream/ReadLineAsync which will hang forever if the socket has no data arriving. Instead, read and parse the lines directly from the SSE source and add a CancellationTokenSource with a timeout of 60 seconds, if no data arrives.

Why
We're getting customer reports of flags not updating correctly when the SDK has been left running for some time.

Testing
Added new Wiremock tests for testing EventSource, also manual testing