### PR TITLE
Include context when logging

### DIFF
--- a/Connected Services/HarnessOpenMetricsAPIService/HarnessOpenMetricsAPI.cs
+++ b/Connected Services/HarnessOpenMetricsAPIService/HarnessOpenMetricsAPI.cs
@@ -22,11 +22,13 @@ namespace io.harness.cfsdk.HarnessOpenMetricsAPIService
         private string _baseUrl = "/api/1.0";
         private System.Net.Http.HttpClient _httpClient;
         private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
-    
+        private ILogger _loggerWithContext;
+
         public Client(System.Net.Http.HttpClient httpClient)
         {
             _httpClient = httpClient;
             _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);
+            _loggerWithContext = Log.ForContext<Client>();
         }
     
         private Newtonsoft.Json.JsonSerializerSettings CreateSerializerSettings()
@@ -108,8 +110,8 @@ namespace io.harness.cfsdk.HarnessOpenMetricsAPIService
     
                         var status_ = (int)response_.StatusCode;
 
-                        Log.Information("API call, url: " + url_);
-                        Log.Information("API call, status: " + status_);
+                        _loggerWithContext.Information("API call, url: " + url_);
+                        _loggerWithContext.Information("API call, status: " + status_);
 
                         if (status_ == 200)
                         {

--- a/client/api/AuthService.cs
+++ b/client/api/AuthService.cs
@@ -24,6 +24,7 @@ namespace io.harness.cfsdk.client.api
         private readonly IConnector connector;
         private readonly Config config;
         private readonly IAuthCallback callback;
+        private readonly ILogger loggerWithContext;
         private Timer authTimer;
         private int retries = 0;
 
@@ -32,6 +33,7 @@ namespace io.harness.cfsdk.client.api
             this.connector = connector;
             this.config = config;
             this.callback = callback;
+            loggerWithContext = Log.ForContext<AuthService>();
         }
         public void Start()
         {
@@ -52,19 +54,19 @@ namespace io.harness.cfsdk.client.api
                 await connector.Authenticate();
                 callback.OnAuthenticationSuccess();
                 Stop();
-                Log.Information("Stopping authentication service");
+                loggerWithContext.Information("Stopping authentication service");
             }
             catch
             {
                 // Exception thrown on Authentication. Timer will retry authentication.
                 if (retries++ >= config.MaxAuthRetries)
                 {
-                    Log.Error($"Max authentication retries reached {retries}");
+                    loggerWithContext.Error($"Max authentication retries reached {retries}");
                     Stop();
                 }
                 else
                 {
-                    Log.Error($"Exception while authenticating, retry ({retries}) in {config.pollIntervalInSeconds}");
+                    loggerWithContext.Error($"Exception while authenticating, retry ({retries}) in {config.pollIntervalInSeconds}");
                 }
             }
         }

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -28,10 +28,13 @@ namespace io.harness.cfsdk.client.api
     {
         private IRepository repository;
         private IEvaluatorCallback callback;
+        private ILogger loggerWithContext;
+
         public Evaluator(IRepository repository, IEvaluatorCallback callback)
         {
             this.repository = repository;
             this.callback = callback;
+            loggerWithContext = Log.ForContext<Evaluator>();
         }
         private Variation EvaluateVariation(string key, dto.Target target, FeatureConfigKind kind)
         {
@@ -217,14 +220,14 @@ namespace io.harness.cfsdk.client.api
                     // check exclude list
                     if (segment.Excluded != null && segment.Excluded.Any(t => t.Identifier.Equals(target.Identifier)))
                     {
-                        Log.Debug($"Target {target.Name} excluded from segment {segment.Name} via exclude list");
+                        loggerWithContext.Debug($"Target {target.Name} excluded from segment {segment.Name} via exclude list");
                         return false;
                     }
 
                     // check include list
                     if (segment.Included != null && segment.Included.Any(t => t.Identifier.Equals(target.Identifier)))
                     {
-                        Log.Debug($"Target {target.Name} included in segment {segment.Name} via include list");
+                        loggerWithContext.Debug($"Target {target.Name} included in segment {segment.Name} via include list");
                         return true;
                     }
 

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -26,6 +26,7 @@ namespace io.harness.cfsdk.client.api
         private IEvaluator evaluator;
         private IMetricsProcessor metric;
         private IConnector connector;
+        private ILogger loggerWithContext;
 
         public event EventHandler InitializationCompleted;
         public event EventHandler<string> EvaluationChanged;
@@ -33,15 +34,22 @@ namespace io.harness.cfsdk.client.api
         private CfClient parent;
         public InnerClient(CfClient parent) { this.parent = parent; }
         public InnerClient(string apiKey, Config config, CfClient parent)
+            : this()
         {
             this.parent = parent;
             Initialize(apiKey, config);
         }
 
         public InnerClient(IConnector connector, Config config, CfClient parent)
+            : this()
         {
             this.parent = parent;
             Initialize(connector, config);
+        }
+
+        private InnerClient()
+        {
+            loggerWithContext = Log.ForContext<InnerClient>();
         }
 
         public void Initialize(string apiKey, Config config)
@@ -61,7 +69,7 @@ namespace io.harness.cfsdk.client.api
         }
         public void Start()
         {
-            Log.Information("Initialize authentication");
+            loggerWithContext.Information("Initialize authentication");
             // Start Authentication flow
             this.authService.Start();
         }
@@ -85,12 +93,12 @@ namespace io.harness.cfsdk.client.api
 
         public void OnStreamConnected()
         {
-            Log.Debug("Stream connected");
+            loggerWithContext.Debug("Stream connected");
             this.polling.Stop();
         }
         public void OnStreamDisconnected()
         {
-            Log.Debug("Stream disconnected");
+            loggerWithContext.Debug("Stream disconnected");
             this.polling.Start();
         }
         #endregion

--- a/client/api/Repository.cs
+++ b/client/api/Repository.cs
@@ -37,11 +37,14 @@ namespace io.harness.cfsdk.client.api
         private ICache cache;
         private IStore store;
         private IRepositoryCallback callback;
+        private ILogger loggerWithContext;
+
         public StorageRepository(ICache cache, IStore store, IRepositoryCallback callback)
         {
             this.cache = cache;
             this.store = store;
             this.callback = callback;
+            loggerWithContext = Log.ForContext<StorageRepository>();
         }
 
         private string FlagKey(string identifier) {  return "flags_" + identifier; }
@@ -84,11 +87,11 @@ namespace io.harness.cfsdk.client.api
             string key = FlagKey(identifier);
             if (store != null)
             {
-                Log.Debug($"Flag {identifier} successfully deleted from store");
+                loggerWithContext.Debug($"Flag {identifier} successfully deleted from store");
                 store.Delete(key);
             }
             this.cache.Delete(key);
-            Log.Debug($"Flag {identifier} successfully deleted from cache");
+            loggerWithContext.Debug($"Flag {identifier} successfully deleted from cache");
             if (this.callback != null)
             {
                 this.callback.OnFlagDeleted(identifier);
@@ -100,11 +103,11 @@ namespace io.harness.cfsdk.client.api
             string key = SegmentKey(identifier);
             if (store != null)
             {
-                Log.Debug($"Segment {identifier} successfully deleted from store");
+                loggerWithContext.Debug($"Segment {identifier} successfully deleted from store");
                 store.Delete(key);
             }
             this.cache.Delete(key);
-            Log.Debug($"Segment {identifier} successfully deleted from cache");
+            loggerWithContext.Debug($"Segment {identifier} successfully deleted from cache");
             if (this.callback != null)
             {
                 this.callback.OnSegmentDeleted(identifier);
@@ -144,7 +147,7 @@ namespace io.harness.cfsdk.client.api
             // or if version is equal 0 (or doesn't exist)
             if( current != null && featureConfig.Version != 0 && current.Version >= featureConfig.Version )
             {
-                Log.Debug($"Flag {identifier} already exists");
+                loggerWithContext.Debug($"Flag {identifier} already exists");
                 return;
             }
 
@@ -178,12 +181,12 @@ namespace io.harness.cfsdk.client.api
         {
             if (this.store == null)
             {
-                Log.Debug($"Item {identifier} successfully cached");
+                loggerWithContext.Debug($"Item {identifier} successfully cached");
                 cache.Set(key, value);
             }
             else
             {
-                Log.Debug($"Item {identifier} successfully stored and cache invalidated");
+                loggerWithContext.Debug($"Item {identifier} successfully stored and cache invalidated");
                 store.Set(key, value);
                 cache.Delete(key);
             }

--- a/client/api/UpdateProcessor.cs
+++ b/client/api/UpdateProcessor.cs
@@ -32,6 +32,7 @@ namespace io.harness.cfsdk.client.api
 
         private IService service;
         private Config config;
+        private ILogger loggerWithContext;
 
         public UpdateProcessor(IConnector connector, IRepository repository, Config config, IUpdateCallback callback)
         {
@@ -39,6 +40,7 @@ namespace io.harness.cfsdk.client.api
             this.repository = repository;
             this.connector = connector;
             this.config = config;
+            loggerWithContext = Log.ForContext<UpdateProcessor>();
         }
 
         public void Start()
@@ -60,9 +62,9 @@ namespace io.harness.cfsdk.client.api
 
         public void Update(Message message, bool manual)
         {
-            if( manual && this.config.StreamEnabled)
+            if (manual && this.config.StreamEnabled)
             {
-                Log.Information("You run the update method manually with the stream enabled. Please turn off the stream in this case.");
+                loggerWithContext.Information("You run the update method manually with the stream enabled. Please turn off the stream in this case.");
             }
             //we got a message from server. Dispatch in separate thread.
             _ = ProcessMessage(message);
@@ -99,9 +101,9 @@ namespace io.harness.cfsdk.client.api
                         this.repository.SetFlag(message.Identifier, feature);
                     }
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
-                    Log.Error($"Error processing flag: {message.Identifier} event: {message.Event}.", ex);
+                    loggerWithContext.Error($"Error processing flag: {message.Identifier} event: {message.Event}.", ex);
                 }
             }
             else if (message.Domain.Equals("target-segment"))
@@ -118,9 +120,9 @@ namespace io.harness.cfsdk.client.api
                         this.repository.SetSegment(message.Identifier, segment);
                     }
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
-                    Log.Error($"Error processing segment: {message.Identifier} event: {message.Event}.", ex);
+                    loggerWithContext.Error($"Error processing segment: {message.Identifier} event: {message.Event}.", ex);
                 }
             }
         }

--- a/client/api/analytics/AnalyticsEventHandler.cs
+++ b/client/api/analytics/AnalyticsEventHandler.cs
@@ -13,11 +13,13 @@ namespace io.harness.cfsdk.client.api.analytics
     {
         private AnalyticsCache analyticsCache;
         private AnalyticsPublisherService analyticsPublisherService;
+        private ILogger loggerWithContext;
 
         public AnalyticsEventHandler( AnalyticsCache analyticsCache, AnalyticsPublisherService analyticsPublisherService)
         {
             this.analyticsCache = analyticsCache;
             this.analyticsPublisherService = analyticsPublisherService;
+            loggerWithContext = Log.ForContext<AnalyticsEventHandler>();
         }
         public void OnEvent(Analytics analytics, long sequence, bool endOfBatch)
         {
@@ -30,7 +32,7 @@ namespace io.harness.cfsdk.client.api.analytics
                     }
                     catch (CfClientException e)
                     {
-                        Log.Warning("Failed to send analytics data to server", e);
+                        loggerWithContext.Warning("Failed to send analytics data to server", e);
                     }
                     break;
                 case EventType.METRICS:

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -29,11 +29,14 @@ namespace io.harness.cfsdk.client.api.analytics
         private AnalyticsPublisherService analyticsPublisherService;
         private IMetricCallback callback;
         private Config config;
+        private ILogger loggerWithContext;
+
         public MetricsProcessor(IConnector connector, Config config, IMetricCallback callback)
         {
             this.analyticsCache = new AnalyticsCache();
             this.callback = callback;
             this.config = config;
+            loggerWithContext = Log.ForContext<MetricsProcessor>();
             this.analyticsPublisherService = new AnalyticsPublisherService(connector, analyticsCache);
             this.ringBuffer = createRingBuffer(config.getBufferSize(), analyticsPublisherService);
         }
@@ -66,7 +69,7 @@ namespace io.harness.cfsdk.client.api.analytics
             long sequence = -1;
             if (!ringBuffer.TryNext(out sequence)) // Grab the next sequence if we can
             {
-                Log.Warning("Insufficient capacity in the analytics ringBuffer");
+                loggerWithContext.Warning("Insufficient capacity in the analytics ringBuffer");
             }
             else
             {
@@ -104,11 +107,11 @@ namespace io.harness.cfsdk.client.api.analytics
             long sequence = -1;
             if (!ringBuffer.TryNext(out sequence)) // Grab the next sequence if we can
             {
-                Log.Warning("Insufficient capacity in the analytics ringBuffer");
+                loggerWithContext.Warning("Insufficient capacity in the analytics ringBuffer");
             }
             else
             {
-                Log.Information("Publishing timerInfo to ringBuffer");
+                loggerWithContext.Information("Publishing timerInfo to ringBuffer");
                 ringBuffer[sequence].EventType = EventType.TIMER; // Get the entry in the Disruptor for the sequence
             }
 

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -30,17 +30,19 @@ namespace io.harness.cfsdk.client.api.analytics
 
         private AnalyticsCache analyticsCache;
         private IConnector connector;
+        private ILogger loggerWithContext;
 
 
         public AnalyticsPublisherService(IConnector connector, AnalyticsCache analyticsCache)
         {
             this.analyticsCache = analyticsCache;
             this.connector = connector;
+            loggerWithContext = Log.ForContext<AnalyticsPublisherService>();
         }
 
         public void sendDataAndResetCache()
         {
-            Log.Information("Reading from queue and building cache, SDL version: " + sdkVersion);
+            loggerWithContext.Information("Reading from queue and building cache, SDL version: " + sdkVersion);
 
             IDictionary<Analytics, int> all = analyticsCache.GetAllElements();
 
@@ -52,20 +54,20 @@ namespace io.harness.cfsdk.client.api.analytics
                     if ((metrics.MetricsData != null && metrics.MetricsData.Count >0)
                         || (metrics.TargetData != null && metrics.TargetData.Count > 0))
                     {
-                        Log.Debug("Sending analytics data :{@a}", metrics);
+                        loggerWithContext.Debug("Sending analytics data :{@a}", metrics);
                         connector.PostMetrics(metrics);
                     }
 
                     stagingTargetSet.ToList().ForEach(element => globalTargetSet.Add(element));
                     stagingTargetSet.Clear();
-                    Log.Information("Successfully sent analytics data to the server");
+                    loggerWithContext.Information("Successfully sent analytics data to the server");
                     analyticsCache.resetCache();
                 }
                 catch (CfClientException ex)
                 {
                     // Clear the set because the cache is only invalidated when there is no
                     // exception, so the targets will reappear in the next iteration
-                    Log.Error("Failed to send metricsData {@e}", ex);
+                    loggerWithContext.Error("Failed to send metricsData {@e}", ex);
                 }
             }
         }

--- a/client/cache/FileMapStore.cs
+++ b/client/cache/FileMapStore.cs
@@ -12,9 +12,12 @@ namespace io.harness.cfsdk.client.api
     public class FileMapStore : IStore
     {
         private string storeName;
+        private ILogger loggerWithContext;
+
         public FileMapStore(string name)
         {
             storeName = name;
+            loggerWithContext = Log.ForContext<FileMapStore>();
             Directory.CreateDirectory(name);
             Array.ForEach(Directory.EnumerateFiles(name).ToArray(), f => File.Delete(f));
         }
@@ -43,7 +46,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch( Exception ex)
             {
-                Log.Error("Failure to deserialize data from file storage", ex);
+                loggerWithContext.Error("Failure to deserialize data from file storage", ex);
                 return null;
             }
         }

--- a/client/connector/FileWatcher.cs
+++ b/client/connector/FileWatcher.cs
@@ -10,6 +10,7 @@ namespace io.harness.cfsdk.client.connector
         private readonly string domain;
         private readonly string path;
         private readonly IUpdateCallback callback;
+        private ILogger loggerWithContext;
 
         private FileSystemWatcher watcher;
 
@@ -18,6 +19,7 @@ namespace io.harness.cfsdk.client.connector
             this.domain = domain;
             this.callback = callback;
             this.path = path;
+            loggerWithContext = Log.ForContext<FileWatcher>();
         }
 
         private void Watcher_Deleted(object sender, FileSystemEventArgs e)
@@ -62,7 +64,7 @@ namespace io.harness.cfsdk.client.connector
             }
             catch(Exception ex)
             {
-                Log.Error($"Error creating fileWatcher at {path}", ex);
+                loggerWithContext.Error($"Error creating fileWatcher at {path}", ex);
             }
         }
 

--- a/client/connector/LocalConnector.cs
+++ b/client/connector/LocalConnector.cs
@@ -17,6 +17,8 @@ namespace io.harness.cfsdk.client.connector
         private string segmentPath;
         private string metricPath;
         private string source;
+        private ILogger loggerWithContext;
+
         public LocalConnector(string source)
         {
             this.source = source;
@@ -24,6 +26,7 @@ namespace io.harness.cfsdk.client.connector
             this.flagPath = Path.Combine(source, "flags");
             this.segmentPath = Path.Combine(source, "segments");
             this.metricPath = Path.Combine(source, "metrics");
+            loggerWithContext = Log.ForContext<LocalConnector>();
 
             Directory.CreateDirectory(this.flagPath);
             Directory.CreateDirectory(this.segmentPath);
@@ -61,7 +64,7 @@ namespace io.harness.cfsdk.client.connector
             }
             catch (Exception ex)
             {
-                Log.Error("Error accessing feature files.", ex);
+                loggerWithContext.Error("Error accessing feature files.", ex);
             }
             return Task.FromResult((IEnumerable<FeatureConfig>)features);
         }
@@ -84,7 +87,7 @@ namespace io.harness.cfsdk.client.connector
             }
             catch(Exception ex)
             {
-                Log.Error("Error accessing segment files.", ex);
+                loggerWithContext.Error("Error accessing segment files.", ex);
             }
             return Task.FromResult((IEnumerable<Segment>)segments);
         }

--- a/client/polling/ShortTermPolling.cs
+++ b/client/polling/ShortTermPolling.cs
@@ -11,22 +11,23 @@ namespace io.harness.cfsdk.client.polling
         private static int MINIMUM_POLLING_INTERVAL = 10000;
         private long pollingInterval;
         private Timer timer;
+        private ILogger loggerWithContext;
 
         public ShortTermPolling(int time)
         {
             pollingInterval = Math.Max(time, MINIMUM_POLLING_INTERVAL);
-
+            loggerWithContext = Log.ForContext<ShortTermPolling>();
         }
 
         public void start(Action<object, ElapsedEventArgs> runnable)
         {
             if (timer != null)
             {
-                Log.Information("POLLING timer - stopping before start");
+                loggerWithContext.Information("POLLING timer - stopping before start");
                 timer.Stop();
                 timer.Dispose();
             }
-            Log.Information("POLLING timer - scheduling new one");
+            loggerWithContext.Information("POLLING timer - scheduling new one");
             timer = new Timer(pollingInterval);
             timer.Elapsed += new ElapsedEventHandler(runnable);
             timer.AutoReset = true;
@@ -38,11 +39,11 @@ namespace io.harness.cfsdk.client.polling
         {
             if (timer != null)
             {
-                Log.Information("POLLING timer - stopping on exit");
+                loggerWithContext.Information("POLLING timer - stopping on exit");
                 timer.Stop();
                 timer.Dispose();
             }
-            Log.Information("POLLING timer - stoped");
+            loggerWithContext.Information("POLLING timer - stoped");
         }
     }
 }


### PR DESCRIPTION
This PR updates all logging to have a source context to allow leveraging of the [Serilog feature](https://github.com/serilog/serilog/wiki/Writing-Log-Events#source-contexts) to support log filtering (e.g. override minimum log level by namespace.)