### PR TITLE
feat: [FFM-7477]: Adding additional headers to SDK requests

### DIFF
--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using io.harness.cfsdk.client.api;
 using io.harness.cfsdk.HarnessOpenAPIService;
+using Microsoft.IdentityModel.Tokens;
 using Serilog;
 
 namespace io.harness.cfsdk.client.connector

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http;

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -33,7 +33,6 @@
   <ItemGroup>
     <PackageReference Include="Disruptor" Version="4.0.0" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="murmurhash" Version="1.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,6 +8,7 @@
     <Version>1.1.7</Version>
     <PackOnBuild>true</PackOnBuild>
     <PackageVersion>1.1.7</PackageVersion>
+    <AssemblyVersion>1.1.7</AssemblyVersion>
     <Authors>support@harness.io</Authors>
     <Copyright>Copyright © 2023 </Copyright>
     <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
@@ -20,7 +21,7 @@
     <Description>Harness Feature Flags (FF) is a feature management solution that enables users to change the software’s functionality, without deploying new code. FF uses feature flags to hide code or behaviours without having to ship new versions of the software. A feature flag is like a powerful if statement.</Description>
     <PackageReleaseNotes>.NET Server SDK for Harness Feature Flag platform</PackageReleaseNotes>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Disruptor" Version="4.0.0" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="murmurhash" Version="1.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/ff-netF48-server-sdk.sln
+++ b/ff-netF48-server-sdk.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ff-server-sdk-test", "tests
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ff-server-sdk-example", "tests\ff-server-sdk-example\ff-server-sdk-example.csproj", "{0CE8570E-1054-4A72-B526-02D580A309C9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "getting_started", "examples\getting_started\getting_started.csproj", "{FD7316AF-9326-4D2A-B218-202A18916480}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{0CE8570E-1054-4A72-B526-02D580A309C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0CE8570E-1054-4A72-B526-02D580A309C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0CE8570E-1054-4A72-B526-02D580A309C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD7316AF-9326-4D2A-B218-202A18916480}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD7316AF-9326-4D2A-B218-202A18916480}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD7316AF-9326-4D2A-B218-202A18916480}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD7316AF-9326-4D2A-B218-202A18916480}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/ff-server-sdk-test/HarnessConnectorTest.cs
+++ b/tests/ff-server-sdk-test/HarnessConnectorTest.cs
@@ -72,9 +72,7 @@ namespace ff_server_sdk_test {
             var mockCallback = new Mock<TestCallback>();
             var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client);
             await connector.Authenticate();
-
-            Assert.That(connector.apiHttpClient.DefaultRequestHeaders.Contains("test"));
-            
+        
             //Act
             var exception = Assert.ThrowsAsync<CfClientException>(async () => await connector.GetFlag("test"));
             

--- a/tests/ff-server-sdk-test/HarnessConnectorTest.cs
+++ b/tests/ff-server-sdk-test/HarnessConnectorTest.cs
@@ -18,8 +18,8 @@ namespace ff_server_sdk_test {
     {
         
         string fakeJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-                         ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbnZpcm9ubWVudCI6InRlc3QiLCJjbHVzdGVySWRlbnRpZmllciI6InRlc3QifQ" +
-                         ".gF0nYhfLrYhzk1oa0fwXZsegewN4xqipCRNaWMSgEXk";
+            ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbnZpcm9ubWVudCI6InRlc3QiLCJjbHVzdGVySWRlbnRpZmllciI6InRlc3QiLCJhY2NvdW50SUQiOiJ0ZXN0In0" +
+            ".MVFJ6Sd0AObZkg3LxKYU9EBMn-t40tPJ-tFd0Ch5EiU";
 
         public class TestCallback : IConnectionCallback
         {
@@ -52,9 +52,9 @@ namespace ff_server_sdk_test {
             var mockHttpClient = MockedHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.Forbidden });
             var client = new Client(mockHttpClient);
             var mockCallback = new Mock<TestCallback>();
-            var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client);
+            var connector = new HarnessConnector("test", new Config(), mockCallback.Object);
             await connector.Authenticate();
-            
+  
             //Act
             var exception = Assert.ThrowsAsync<CfClientException>(async () => await connector.GetFlag("test"));
             
@@ -72,6 +72,10 @@ namespace ff_server_sdk_test {
             var mockCallback = new Mock<TestCallback>();
             var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client);
             await connector.Authenticate();
+
+            //connector.apiHttpClient.
+
+            Assert.That(connector.apiHttpClient.DefaultRequestHeaders.Contains("test"));
             
             //Act
             var exception = Assert.ThrowsAsync<CfClientException>(async () => await connector.GetFlag("test"));

--- a/tests/ff-server-sdk-test/HarnessConnectorTest.cs
+++ b/tests/ff-server-sdk-test/HarnessConnectorTest.cs
@@ -52,7 +52,7 @@ namespace ff_server_sdk_test {
             var mockHttpClient = MockedHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.Forbidden });
             var client = new Client(mockHttpClient);
             var mockCallback = new Mock<TestCallback>();
-            var connector = new HarnessConnector("test", new Config(), mockCallback.Object);
+            var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client);
             await connector.Authenticate();
   
             //Act
@@ -72,8 +72,6 @@ namespace ff_server_sdk_test {
             var mockCallback = new Mock<TestCallback>();
             var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client);
             await connector.Authenticate();
-
-            //connector.apiHttpClient.
 
             Assert.That(connector.apiHttpClient.DefaultRequestHeaders.Contains("test"));
             


### PR DESCRIPTION
# What

this adds Harness-SDK-Info, Harness-EnvironmentID, Harness-AccountID http headers

# Why

- Feature parity with other sdks 
- used to help with logging/debugging