### PR TITLE
[FFM-6904]: FFM-6904-sending-sdk-version-in-metrics-payload

### DIFF
--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -7,6 +7,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace io.harness.cfsdk.client.api.analytics
@@ -26,7 +27,7 @@ namespace io.harness.cfsdk.client.api.analytics
         private static string SDK_VERSION = "SDK_VERSION";
 
 
-        private Version sdkVersion = typeof(AnalyticsPublisherService).Assembly.GetName().Version;
+        private string sdkVersion = Assembly.GetExecutingAssembly().GetName().ToString();
 
         private AnalyticsCache analyticsCache;
         private IConnector connector;
@@ -130,7 +131,7 @@ namespace io.harness.cfsdk.client.api.analytics
                 setMetricsAttriutes(metricsData, SDK_TYPE, SERVER);
 
                 setMetricsAttriutes(metricsData, SDK_LANGUAGE, ".NET");
-                setMetricsAttriutes(metricsData, SDK_VERSION, sdkVersion.ToString() );
+                setMetricsAttriutes(metricsData, SDK_VERSION, sdkVersion);
                 metrics.MetricsData.Add(metricsData);
             }
 


### PR DESCRIPTION
# What
Correctly pulls in the Assembly version when sending metrics


# Why
Fixes an issue where the SDK version (aka Assembly version) was being sent incorrectly in the metrics payload

# Testing
Manual
