### PR TITLE
(FFM-7472): Standardise log messages

### DIFF
--- a/client/api/AuthService.cs
+++ b/client/api/AuthService.cs
@@ -52,19 +52,19 @@ namespace io.harness.cfsdk.client.api
                 await connector.Authenticate();
                 callback.OnAuthenticationSuccess();
                 Stop();
-                Log.Information("Stopping authentication service");
+                Log.Debug("Stopping authentication service");
             }
             catch
             {
                 // Exception thrown on Authentication. Timer will retry authentication.
                 if (retries++ >= config.MaxAuthRetries)
                 {
-                    Log.Error($"Max authentication retries reached {retries}");
+                    Log.Error($"SDKCODE(auth:2001): Authentication failed. Max authentication retries reached {retries} - defaults will be served");
                     Stop();
                 }
                 else
                 {
-                    Log.Error($"Exception while authenticating, retry ({retries}) in {config.pollIntervalInSeconds}");
+                    Log.Warning($"SDKCODE(auth:2003): Retrying to authenticate. Retry ({retries}) in {config.pollIntervalInSeconds} Seconds");
                 }
             }
         }

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -118,7 +118,7 @@ namespace io.harness.cfsdk.client.api
 
         private void logEvaluatiionFailureError(FeatureConfigKind kind, string featureKey, dto.Target target, string defaultValue)
         {
-            Log.Error($"SDK_EVAL_6001: Failed to evaluate {kind} variation for {{ \"target\": \"{target.Identifier}\", \"flag\": \"{featureKey}\"}} and the default variation {defaultValue} is being returned");
+            Log.Warning($"SDKCODE(eval:6001): Failed to evaluate {kind} variation for {{ \"target\": \"{target.Identifier}\", \"flag\": \"{featureKey}\"}} and the default variation {defaultValue} is being returned");
         }
 
         private bool checkPreRequisite(FeatureConfig parentFeatureConfig, dto.Target target)

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -63,7 +63,7 @@ namespace io.harness.cfsdk.client.api
         }
         public void Start()
         {
-            Log.Information("Initialize authentication");
+            Log.Debug("Authenticating");
             // Start Authentication flow
             this.authService.Start();
         }
@@ -87,12 +87,12 @@ namespace io.harness.cfsdk.client.api
 
         public void OnStreamConnected()
         {
-            Log.Debug("Stream connected");
+            Log.Information("SDKCODE(stream:5000): SSE stream connected ok");
             this.polling.Stop();
         }
         public void OnStreamDisconnected()
         {
-            Log.Debug("Stream disconnected");
+            Log.Information("SDKCODE(stream:5001): SSE stream disconnected");
             this.polling.Start();
         }
         #endregion
@@ -103,6 +103,8 @@ namespace io.harness.cfsdk.client.api
         public void OnAuthenticationSuccess()
         {
             // after successfull authentication, start
+            Log.Information("SDKCODE(auth:2000): Authenticated ok");
+
             polling.Start();
             update.Start();
             metric.Start();
@@ -161,6 +163,7 @@ namespace io.harness.cfsdk.client.api
 
         private void OnNotifyInitializationCompleted()
         {
+            Log.Information("SDKCODE(init:1000): The SDK has successfully initialized");
             InitializationCompleted?.Invoke(parent, EventArgs.Empty);
         }
         private void OnNotifyEvaluationChanged(string identifier)

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -67,13 +67,13 @@ namespace io.harness.cfsdk.client.api
 
         public void Start()
         {
-            Log.Information($"Starting PollingProcessor with request interval: {config.pollIntervalInSeconds}");
+            Log.Debug($"SDKCODE(poll:4000): Polling started, intervalMs: {config.PollIntervalInMiliSeconds}");
             // start timer which will initiate periodic reading of flags and segments
             pollTimer = new Timer(OnTimedEventAsync, null, 0, config.PollIntervalInMiliSeconds);
         }
         public void Stop()
         {
-            Log.Information("Stopping PollingProcessor");
+            Log.Debug("SDKCODE(poll:4001): Polling stopped");
             // stop timer
             if (pollTimer == null) return;
             pollTimer.Dispose();
@@ -131,7 +131,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch(Exception ex)
             {
-                Log.Information($"Polling will retry in {config.pollIntervalInSeconds}");
+                Log.Warning($"Polling failed with error: {ex.Message}. Will retry in {config.pollIntervalInSeconds}");
                 callback.OnPollError(ex.Message);
             }
         }

--- a/client/api/UpdateProcessor.cs
+++ b/client/api/UpdateProcessor.cs
@@ -62,7 +62,7 @@ namespace io.harness.cfsdk.client.api
         {
             if( manual && this.config.StreamEnabled)
             {
-                Log.Information("You run the update method manually with the stream enabled. Please turn off the stream in this case.");
+                Log.Information("You ran the update method manually with the stream enabled. Please turn off the stream in this case.");
             }
             //we got a message from server. Dispatch in separate thread.
             _ = ProcessMessage(message);

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -56,14 +56,14 @@ namespace io.harness.cfsdk.client.api.analytics
 
                     stagingTargetSet.ToList().ForEach(element => globalTargetSet.Add(element));
                     stagingTargetSet.Clear();
-                    Log.Information("Successfully sent analytics data to the server");
+                    Log.Debug("Successfully sent analytics data to the server");
                     analyticsCache.resetCache();
                 }
                 catch (CfClientException ex)
                 {
                     // Clear the set because the cache is only invalidated when there is no
                     // exception, so the targets will reappear in the next iteration
-                    Log.Error("Failed to send metricsData {@e}", ex);
+                    Log.Error($"SDKCODE(stream:7002): Posting metrics failed, reason: {ex.Message}");
                 }
             }
         }

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -39,7 +39,7 @@ namespace io.harness.cfsdk.client.connector
 
         public void Stop()
         {
-            Log.Information("Stopping EventSource service.");
+            Log.Debug("Stopping EventSource service.");
         }
 
         private string ReadLine(Stream stream, int timeoutMs)
@@ -69,7 +69,7 @@ namespace io.harness.cfsdk.client.connector
             try
             {
 
-                Log.Information("Starting EventSource service.");
+                Log.Debug("Starting EventSource service.");
                 using (Stream stream = await this.httpClient.GetStreamAsync(url))
                 {
                     callback.OnStreamConnected();
@@ -83,7 +83,7 @@ namespace io.harness.cfsdk.client.connector
                             continue;
                         }
 
-                        Log.Information($"EventSource message received {message}");
+                        Log.Information($"SDKCODE(stream:5002): SSE event received {message}");
 
                         // parse message
                         var jsonMessage = JObject.Parse("{" + message + "}");

--- a/client/polling/ShortTermPolling.cs
+++ b/client/polling/ShortTermPolling.cs
@@ -22,11 +22,11 @@ namespace io.harness.cfsdk.client.polling
         {
             if (timer != null)
             {
-                Log.Information("POLLING timer - stopping before start");
+                Log.Debug("POLLING timer - stopping before start");
                 timer.Stop();
                 timer.Dispose();
             }
-            Log.Information("POLLING timer - scheduling new one");
+            Log.Debug("POLLING timer - scheduling new one");
             timer = new Timer(pollingInterval);
             timer.Elapsed += new ElapsedEventHandler(runnable);
             timer.AutoReset = true;
@@ -38,11 +38,11 @@ namespace io.harness.cfsdk.client.polling
         {
             if (timer != null)
             {
-                Log.Information("POLLING timer - stopping on exit");
+                Log.Debug("POLLING timer - stopping on exit");
                 timer.Stop();
                 timer.Dispose();
             }
-            Log.Information("POLLING timer - stoped");
+            Log.Debug("POLLING timer - stoped");
         }
     }
 }

--- a/tests/ff-server-sdk-test/connector/EventSourceTest.cs
+++ b/tests/ff-server-sdk-test/connector/EventSourceTest.cs
@@ -64,13 +64,13 @@ namespace ff_server_sdk_test.connector
 
             public void OnStreamConnected()
             {
-                Log.Information("Stream connected");
+                Log.Information("SDKCODE(stream:5000): SSE stream connected ok");
                 ConnectCount++;
             }
 
             public void OnStreamDisconnected()
             {
-                Log.Information("Stream disconnected");
+                Log.Information("SDKCODE(stream:5001): SSE stream disconnected");
                 DisconnectCount++;
                 disconnectLatch.Signal();
             }


### PR DESCRIPTION
FFM-7472 - Standardise Init / Auth / Close / Polling / Streaming / Metrics log messages and error messages

What
Adding standardised SDK error codes + pushing some logs down to debug to reduce noise

Why
Each SDK uses different log messages for its lifecycle. We want to standardise messages across SDKs with a unique code.

Testing
Manual testing + unit testing