### PR TITLE
(FFM-8128): Fixes handling of null targets 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vs
 bin
 obj
+.vscode

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -118,7 +118,7 @@ namespace io.harness.cfsdk.client.api
 
         private void logEvaluatiionFailureError(FeatureConfigKind kind, string featureKey, dto.Target target, string defaultValue)
         {
-            Log.Warning($"SDKCODE(eval:6001): Failed to evaluate {kind} variation for {{ \"target\": \"{target.Identifier}\", \"flag\": \"{featureKey}\"}} and the default variation {defaultValue} is being returned");
+            Log.Warning($"SDKCODE(eval:6001): Failed to evaluate {kind} variation for {{ \"target\": \"{target}\", \"flag\": \"{featureKey}\"}} and the default variation {defaultValue} is being returned");
         }
 
         private bool checkPreRequisite(FeatureConfig parentFeatureConfig, dto.Target target)
@@ -242,6 +242,11 @@ namespace io.harness.cfsdk.client.api
 
         private string EvaluateDistribution(FeatureConfig featureConfig, dto.Target target)
         {
+            if (featureConfig.Rules == null || target == null)
+            {
+                return null;
+            }
+
             DistributionProcessor distributionProcessor = new DistributionProcessor(featureConfig.DefaultServe);
             return distributionProcessor.loadKeyName(target);
         }

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -40,8 +40,6 @@ namespace io.harness.cfsdk.client.api.analytics
 
         public void sendDataAndResetCache()
         {
-            Console.WriteLine("sendDataAndResetCache:" + analyticsCache.ToString());
-
             IDictionary<Analytics, int> all = analyticsCache.GetAllElements();
 
             if (all.Count != 0)
@@ -83,7 +81,7 @@ namespace io.harness.cfsdk.client.api.analytics
                 TargetData targetData = new TargetData();
                 // Set Metrics data
                 MetricsData metricsData = new MetricsData();
-          
+
                 Analytics analytics = entry.Key;
                 dto.Target target = analytics.Target;
 

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -40,6 +40,8 @@ namespace io.harness.cfsdk.client.api.analytics
 
         public void sendDataAndResetCache()
         {
+            Console.WriteLine("sendDataAndResetCache:" + analyticsCache.ToString());
+
             IDictionary<Analytics, int> all = analyticsCache.GetAllElements();
 
             if (all.Count != 0)
@@ -81,14 +83,15 @@ namespace io.harness.cfsdk.client.api.analytics
                 TargetData targetData = new TargetData();
                 // Set Metrics data
                 MetricsData metricsData = new MetricsData();
-             
+          
                 Analytics analytics = entry.Key;
-                HashSet<string> privateAttributes = analytics.Target.PrivateAttributes;
                 dto.Target target = analytics.Target;
+
                 FeatureConfig featureConfig = analytics.FeatureConfig;
                 Variation variation = analytics.Variation;
-                if (!globalTargetSet.Contains(target) && !target.IsPrivate)
+                if (target != null && !globalTargetSet.Contains(target) && !target.IsPrivate)
                 {
+                    HashSet<string> privateAttributes = analytics.Target.PrivateAttributes;
                     stagingTargetSet.Add(target);
                     Dictionary<string, string> attributes = target.Attributes;
                     attributes.ToList().ForEach(el =>
@@ -109,6 +112,16 @@ namespace io.harness.cfsdk.client.api.analytics
                            }
                            targetData.Attributes.Add(keyValue);
                        });
+
+                    if (target.IsPrivate)
+                    {
+                        setMetricsAttributes(metricsData, TARGET_ATTRIBUTE, ANONYMOUS_TARGET);
+                    }
+                    else
+                    {
+                        setMetricsAttributes(metricsData, TARGET_ATTRIBUTE, target.Identifier);
+                    }
+                       
                     targetData.Identifier = target.Identifier;
                     targetData.Name = target.Name;
                     metrics.TargetData.Add(targetData);
@@ -117,28 +130,21 @@ namespace io.harness.cfsdk.client.api.analytics
                 metricsData.Timestamp = (long)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalMilliseconds;
                 metricsData.Count = entry.Value;
                 metricsData.MetricsType = MetricsDataMetricsType.FFMETRICS;
-                setMetricsAttriutes(metricsData, FEATURE_NAME_ATTRIBUTE, featureConfig.Feature);
-                setMetricsAttriutes(metricsData, VARIATION_IDENTIFIER_ATTRIBUTE, variation.Identifier);
-                setMetricsAttriutes(metricsData, VARIATION_VALUE_ATTRIBUTE, variation.Value);
-                if (target.IsPrivate)
-                {
-                    setMetricsAttriutes(metricsData, TARGET_ATTRIBUTE, ANONYMOUS_TARGET);
-                }
-                else
-                {
-                    setMetricsAttriutes(metricsData, TARGET_ATTRIBUTE, target.Identifier);
-                }
-                setMetricsAttriutes(metricsData, SDK_TYPE, SERVER);
+                setMetricsAttributes(metricsData, FEATURE_NAME_ATTRIBUTE, featureConfig.Feature);
+                setMetricsAttributes(metricsData, VARIATION_IDENTIFIER_ATTRIBUTE, variation.Identifier);
+                setMetricsAttributes(metricsData, VARIATION_VALUE_ATTRIBUTE, variation.Value);
 
-                setMetricsAttriutes(metricsData, SDK_LANGUAGE, ".NET");
-                setMetricsAttriutes(metricsData, SDK_VERSION, sdkVersion);
+                setMetricsAttributes(metricsData, SDK_TYPE, SERVER);
+
+                setMetricsAttributes(metricsData, SDK_LANGUAGE, ".NET");
+                setMetricsAttributes(metricsData, SDK_VERSION, sdkVersion);
                 metrics.MetricsData.Add(metricsData);
             }
 
             return metrics;
         }
 
-        private void setMetricsAttriutes(MetricsData metricsData, String key, String value)
+        private void setMetricsAttributes(MetricsData metricsData, String key, String value)
         {
             KeyValue metricsAttributes = new KeyValue();
             metricsAttributes.Key = key;


### PR DESCRIPTION
WHAT: When a user passes in a `null` as the Target value of an evaluation
request, the metrics processor received a NullPointerException trying to parse
the target and add it to the TargetData.

FIX: The fix is to allow the logging and evaluation logic to handle the null
value as opposed to trying to dereference the Target attributes. Also in the
prepareMessageBody function, to handle the Target Data parsing separately from
the evaluation metrics, so that evaluation counts still get sent in, even if
the Target data has a null value.