### PR TITLE
[FFM-9207] - Fix version/account/env meta data reported in headers

### DIFF
--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -220,7 +220,7 @@ namespace io.harness.cfsdk.client.connector
                 }                
                 environment = jwtToken.Payload["environment"].ToString();
                 cluster = jwtToken.Payload["clusterIdentifier"].ToString();
-                var environmentIdentifier = jwtToken.Payload.GetValueOrDefault("environmentIdentifier", environment).ToString();
+                var environmentIdentifier = jwtToken.Payload.ContainsKey("environmentIdentifier") ? jwtToken.Payload["clusterIdentifier"].ToString() : environment;
 
                 foreach (var httpClient in new[] { apiHttpClient, metricHttpClient, sseHttpClient })
                 {

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -220,13 +220,18 @@ namespace io.harness.cfsdk.client.connector
                 }                
                 environment = jwtToken.Payload["environment"].ToString();
                 cluster = jwtToken.Payload["clusterIdentifier"].ToString();
-                var environmentIdentifier = jwtToken.Payload["environmentIdentifier"].ToString();
+                var environmentIdentifier = jwtToken.Payload.GetValueOrDefault("environmentIdentifier", environment).ToString();
 
                 foreach (var httpClient in new[] { apiHttpClient, metricHttpClient, sseHttpClient })
                 {
                     httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-                    httpClient.DefaultRequestHeaders.Add("Harness-EnvironmentID", environmentIdentifier ?? environment);
-                    if (accountID != null && accountID.Length > 0)
+
+                    if (!String.IsNullOrEmpty(environmentIdentifier))
+                    {
+                        httpClient.DefaultRequestHeaders.Add("Harness-EnvironmentID", environmentIdentifier);
+                    }
+
+                    if (!String.IsNullOrEmpty(accountID))
                     {
                         httpClient.DefaultRequestHeaders.Add("Harness-AccountID", accountID);
                     }


### PR DESCRIPTION
[FFM-9207] - Fix version/account/env meta data reported in headers

What
Fixes the following headers to report the correct info: Harness-SDK-Info, Harness-EnvironmentID, Harness-AccessID

Why
Metadata is currently invalid and doesn't show any useful information

Testing
Manual + proxy

[FFM-9207]: https://harness.atlassian.net/browse/FFM-9207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ