### PR TITLE
[FFM-9219] - Rules operator 'equal_sensitive' not working correctly

### DIFF
--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -321,7 +321,7 @@ namespace io.harness.cfsdk.client.api
                     return attrStr.Contains(value);
                 case "equal":
                     return attrStr.ToLower().Equals(value.ToLower());
-                case "attrStr":
+                case "equal_sensitive":
                     return attrStr.Equals(value);
                 case "in":
                     return clause.Values.Contains(attrStr);


### PR DESCRIPTION
What
Fixes a typo in the evaluator code where an incorrect string was being used in the switch statement.

Why
Lots of tests that have rules doing case sensitive comparisons are failing

Testing
Manual + testgrid

With this fix the following tests are now passing:

Custom_SDK_:_GroupRules;Type=Bool;State=Enabled;EqualsThree;Should_Return_false_for_Target_three Custom_SDK_:_GroupRules;Type=Bool;State=Enabled;GroupWithMultipleOrRules;Should_Return_true_for_Target_three Custom_SDK_:_GroupRules;Bool;Enabled;StartsWithTEqualsThreE;Should_Return_true_for_Target_ThreE Custom_SDK_:_GroupRules;Bool;Enabled;StartsWithtGroupWithMultipleOrRules;Should_Return_true_for_Target_three Custom_SDK_:_GroupRules;Type=Bool;State=Enabled;AllRules;Return_true_for_Target_one Custom_SDK_:_GroupRules;Type=JSON;State=Enabled;EqualsThree;Should_Return_emptyJSON_for_Target_three Custom_SDK_:_GroupRules;Type=JSON;State=Enabled;GroupWithMultipleOrRules;Should_Return_emptyJSON_for_Target_three Custom_SDK_:_GroupRules;Type=JSON;State=Enabled;Excludestwo;EndsWithe;Return_emptyJSON_for_Target_THREE Custom_SDK_:_GroupRules;Type=JSON;State=Enabled;AllRules;Return_emptyJSON_for_Target_one Custom_SDK_:_GroupRules;Type=Number;State=Enabled;EqualsThree;Should_Return_324523_for_Target_three Custom_SDK_:_GroupRules;Type=Number;State=Enabled;GroupWithMultipleOrRules;Should_Return_324523_for_Target_three Custom_SDK_:_GroupRules;Type=Num;State=Enabled;Excludestwo;EndsWithe;Return_324523_for_Target_THREE Custom_SDK_:_GroupRules;Type=Num;State=Enabled;AllRules;Return_324523_for_Target_one Custom_SDK_:_GroupRules;Type=String;State=Enabled;EqualsThree;Should_Return_thehobbit_for_Target_three Custom_SDK_:_GroupRules;Type=String;State=Enabled;WithMultipleOrRules;Should_Return_theHobbit_for_Target_three Custom_SDK_:_GroupRules;Type=Str;State=Enabled;Excludestwo;EndsWithe;Return_thehobbit_for_Target_THREE Custom_SDK_:_GroupRules;Type=Str;State=Enabled;AllRules;Return_thehobbit_for_Target_one