### PR TITLE
[FFM-9217] - Evaluator not processing all rules in segments

### DIFF
--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -275,7 +275,10 @@ namespace io.harness.cfsdk.client.api
                     if (segment.Rules != null)
                     {
                         Clause firstSuccess = segment.Rules.FirstOrDefault(r => EvaluateClause(r, target));
-                        return firstSuccess != null;
+                        if (firstSuccess != null)
+                        {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
[FFM-9217] - Evaluator not processing all rules in segments

What
Fix segment loop not to abort too early when a clause evaluations to false

Why
Clauses are treated like OR statements so we should continue to process the remaining. Only short circuit when we get true.

Testing
Manual + testgrid

With this fix, the following tests now pass

Custom_SDK_:_GroupRules;Type=Bool;State=Enabled;MultiGroup;EndsWithE;Should_Return_True_for_Target_Two Custom_SDK_:_GroupRules;Type=JSON;State=Enabled;MultiGroup;EndsWithE;Should_Return_emptyJSON_for_Target_Two Custom_SDK_:_GroupRules;Type=Num;State=Enabled;MultiGroup;EndsWithE;Should_Return_324523_for_Target_Two Custom_SDK_:_GroupRules;Type=Str;State=Enabled;MultiGroup;EndsWithE;Should_Return_thehobbit_for_Target_Two