### PR TITLE
[FFM-9220] - SDK should enforce minimum poll interval

### DIFF
--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -67,9 +67,17 @@ namespace io.harness.cfsdk.client.api
 
         public void Start()
         {
-            Log.Debug($"SDKCODE(poll:4000): Polling started, intervalMs: {config.PollIntervalInMiliSeconds}");
+            var intervalMs = config.PollIntervalInMiliSeconds;
+
+            if (intervalMs < 60000)
+            {
+                Log.Warning("Poll interval cannot be less than 60 seconds");
+                intervalMs = 60000;
+            }
+
+            Log.Debug($"SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}");
             // start timer which will initiate periodic reading of flags and segments
-            pollTimer = new Timer(OnTimedEventAsync, null, 0, config.PollIntervalInMiliSeconds);
+            pollTimer = new Timer(OnTimedEventAsync, null, 0, intervalMs);
         }
         public void Stop()
         {


### PR DESCRIPTION
[FFM-9220] - SDK should enforce minimum poll interval

What
Don't allow poll interval to be less than 1 minute. If it is, use 60 seconds as the interval and log a warning.

Why
Ensure SDK usage remains fair and backend servers are not overloaded with polling requests

Testing
Manual

[FFM-9220]: https://harness.atlassian.net/browse/FFM-9220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ