### PR TITLE
FFM-9392 - Support Microsoft.Extensions.Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For a sample FF .NET SDK project, see our [test .NET project](examples/getting_s
 [.NET Framework >= 4.8](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48)<br>
 or<br>
 [.Net 5.0.104](https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-using-the-dotnet-cli) or newer (dotnet --version)<br>
-The library is packaged as multi-target supporting `netstandard2.0` set of API's and additionaly targets `net461` for older frameworks.
+The library is packaged as multi-target supporting `net5.0`, `net6.0` and `net7.0`.
 
 
 ## Quickstart

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,9 @@ if [ "$DOTNET_VERSION" -lt 7 ]; then
 	exit 1
 fi
 
-dotnet pack
+set -x
+
+dotnet pack ff-netF48-server-sdk.csproj
 
 # Install Tools needed for build
 dotnet tool install --global coverlet.console --version 3.2.0
@@ -17,13 +19,13 @@ dotnet tool restore
 
 # Install Libraries needed for build and buld
 dotnet add package JUnitTestLogger --version 1.1.0 
-dotnet restore
-dotnet build --no-restore
+dotnet restore ff-netF48-server-sdk.csproj
+dotnet build ff-netF48-server-sdk.csproj --no-restore
 
 
 # Run tests
 echo "Generating Test Report"
 export MSBUILDDISABLENODEREUSE=1
-dotnet test -v=n --blame-hang --logger:"junit;LogFilePath=junit.xml" -nodereuse:false
+dotnet test tests/ff-server-sdk-test/ff-server-sdk-test.csproj -v=n --blame-hang --logger:"junit;LogFilePath=junit.xml" -nodereuse:false
 ls -l
 echo "Done"

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,13 @@
+
+echo ".NET version installed:"
+dotnet --version
+
+DOTNET_VERSION=$(dotnet --version | cut -d. -f1)
+if [ "$DOTNET_VERSION" -lt 7 ]; then
+	echo "FF .NET SDK requires .NET 7 or later to build. Aborting"
+	exit 1
+fi
+
 dotnet pack
 
 # Install Tools needed for build

--- a/client/api/AuthService.cs
+++ b/client/api/AuthService.cs
@@ -62,12 +62,12 @@ namespace io.harness.cfsdk.client.api
                 // Exception thrown on Authentication. Timer will retry authentication.
                 if (retries++ >= config.MaxAuthRetries)
                 {
-                    logger.LogError(ex, $"SDKCODE(auth:2001): Authentication failed. Max authentication retries reached {retries} - defaults will be served");
+                    logger.LogError(ex, "SDKCODE(auth:2001): Authentication failed. Max authentication retries reached {retries} - defaults will be served", retries);
                     Stop();
                 }
                 else
                 {
-                    logger.LogWarning(ex, $"SDKCODE(auth:2003): Retrying to authenticate. Retry ({retries}) in {config.pollIntervalInSeconds} Seconds. Reason: {ex.Message}");
+                    logger.LogWarning(ex, "SDKCODE(auth:2003): Retrying to authenticate. Retry {retries} in {pollIntervalInSeconds} seconds. Reason: {reason}", retries, config.pollIntervalInSeconds, ex.Message);
                 }
             }
         }

--- a/client/api/AuthService.cs
+++ b/client/api/AuthService.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using io.harness.cfsdk.client.connector;
 using io.harness.cfsdk.HarnessOpenAPIService;
-using Serilog;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace io.harness.cfsdk.client.api
 {
@@ -22,17 +22,19 @@ namespace io.harness.cfsdk.client.api
     /// </summary>
     internal class AuthService : IAuthService
     {
+        private ILogger logger;
         private readonly IConnector connector;
         private readonly Config config;
         private readonly IAuthCallback callback;
         private Timer authTimer;
         private int retries = 0;
 
-        public AuthService(IConnector connector, Config config, IAuthCallback callback)
+        public AuthService(IConnector connector, Config config, IAuthCallback callback, ILoggerFactory loggerFactory)
         {
             this.connector = connector;
             this.config = config;
             this.callback = callback;
+            this.logger = loggerFactory.CreateLogger<AuthService>();
         }
         public void Start()
         {
@@ -53,19 +55,19 @@ namespace io.harness.cfsdk.client.api
                 await connector.Authenticate();
                 callback.OnAuthenticationSuccess();
                 Stop();
-                Log.Debug("Stopping authentication service");
+                logger.LogDebug("Stopping authentication service");
             }
             catch (Exception ex)
             {
                 // Exception thrown on Authentication. Timer will retry authentication.
                 if (retries++ >= config.MaxAuthRetries)
                 {
-                    Log.Error($"SDKCODE(auth:2001): Authentication failed. Max authentication retries reached {retries} - defaults will be served");
+                    logger.LogError(ex, $"SDKCODE(auth:2001): Authentication failed. Max authentication retries reached {retries} - defaults will be served");
                     Stop();
                 }
                 else
                 {
-                    Log.Warning($"SDKCODE(auth:2003): Retrying to authenticate. Retry ({retries}) in {config.pollIntervalInSeconds} Seconds. Reason: {ex}");
+                    logger.LogWarning(ex, $"SDKCODE(auth:2003): Retrying to authenticate. Retry ({retries}) in {config.pollIntervalInSeconds} Seconds. Reason: {ex.Message}");
                 }
             }
         }

--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -1,10 +1,9 @@
 ﻿using io.harness.cfsdk.client.connector;
 using Newtonsoft.Json.Linq;
-using Serilog;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 
 namespace io.harness.cfsdk.client.api
 {
@@ -36,7 +35,7 @@ namespace io.harness.cfsdk.client.api
         private static readonly Lazy<CfClient> lazy = new Lazy<CfClient>(() => new CfClient());
         public static ICfClient Instance { get { return lazy.Value; } }
 
-        private readonly InnerClient client = null;
+        private readonly InnerClient client;
 
         public event EventHandler InitializationCompleted
         {
@@ -54,19 +53,28 @@ namespace io.harness.cfsdk.client.api
         public CfClient(IConnector connector) : this(connector, Config.Builder().Build()) { }
         public CfClient()
         {
-            Log.Logger = new LoggerConfiguration().WriteTo.Debug().CreateLogger();
-            client = new InnerClient(this);
+            client = new InnerClient(this, SetUpDefaultLogging(null));
         }
         public CfClient(string apiKey, Config config)
         {
-            Log.Logger = new LoggerConfiguration().WriteTo.Debug().CreateLogger();
-            client = new InnerClient(apiKey, config, this);
+            client = new InnerClient(apiKey, config, this,  SetUpDefaultLogging(config));
         }
         public CfClient(IConnector connector, Config config)
         {
-            Log.Logger = new LoggerConfiguration().WriteTo.Debug().CreateLogger();
-            client = new InnerClient(connector, config, this);
+            client = new InnerClient(connector, config, this, SetUpDefaultLogging(config));
         }
+
+        private ILoggerFactory SetUpDefaultLogging(Config config)
+        {
+            return LoggerFactory.Create(builder =>
+            {
+                 builder
+                    .AddFilter("Microsoft", LogLevel.Warning)
+                    .AddFilter("System", LogLevel.Warning)
+                    .AddConsole();
+            });
+        }
+
         // start authentication with server
         public async Task InitializeAndWait()
         {

--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -66,6 +66,12 @@ namespace io.harness.cfsdk.client.api
 
         private ILoggerFactory SetUpDefaultLogging(Config config)
         {
+            if (config != null && config.LoggerFactory != null)
+            {
+                return config.LoggerFactory;
+            }
+
+            // Default logging is to console
             return LoggerFactory.Create(builder =>
             {
                  builder

--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using io.harness.cfsdk.client.cache;
+using Microsoft.Extensions.Logging;
 
 namespace io.harness.cfsdk.client.api
 {
@@ -68,6 +69,8 @@ namespace io.harness.cfsdk.client.api
 
         public long MetricsServiceAcceptableDuration { get => metricsServiceAcceptableDuration;  }
         internal long metricsServiceAcceptableDuration = 10000;
+
+        public ILoggerFactory LoggerFactory { get; set; }
 
         public Config(string configUrl, string eventUrl, bool streamEnabled, int pollIntervalInSeconds, bool analyticsEnabled, int frequency, int bufferSize,  int connectionTimeout, int readTimeout, int writeTimeout, bool debug, long metricsServiceAcceptableDuration)
         {
@@ -183,6 +186,13 @@ namespace io.harness.cfsdk.client.api
         public ConfigBuilder debug(bool debug)
         {
             this.configtobuild.debug = debug;
+            return this;
+        }
+
+        /** Set an ILoggerFactory for the SDK. note: cannot be used in conjunction with getInstance() */
+        public ConfigBuilder LoggerFactory(ILoggerFactory loggerFactory)
+        {
+            this.configtobuild.LoggerFactory = loggerFactory;
             return this;
         }
     }

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -6,8 +6,8 @@ using System.Text.RegularExpressions;
 using io.harness.cfsdk.client.api.rules;
 using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.HarnessOpenAPIService;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
-using Serilog;
 
 [assembly: InternalsVisibleToAttribute("ff-server-sdk-test")]
 
@@ -27,12 +27,15 @@ namespace io.harness.cfsdk.client.api
 
     internal class Evaluator : IEvaluator
     {
+        private readonly ILogger<Evaluator> logger;
         private IRepository repository;
         private IEvaluatorCallback callback;
-        public Evaluator(IRepository repository, IEvaluatorCallback callback)
+
+        public Evaluator(IRepository repository, IEvaluatorCallback callback, ILoggerFactory loggerFactory)
         {
             this.repository = repository;
             this.callback = callback;
+            this.logger = loggerFactory.CreateLogger<Evaluator>();
         }
         private Variation EvaluateVariation(string key, dto.Target target, FeatureConfigKind kind)
         {
@@ -118,7 +121,7 @@ namespace io.harness.cfsdk.client.api
 
         private void logEvaluatiionFailureError(FeatureConfigKind kind, string featureKey, dto.Target target, string defaultValue)
         {
-            Log.Warning($"SDKCODE(eval:6001): Failed to evaluate {kind} variation for {{ \"target\": \"{target}\", \"flag\": \"{featureKey}\"}} and the default variation {defaultValue} is being returned");
+            logger.LogWarning($"SDKCODE(eval:6001): Failed to evaluate {kind} variation for {{ \"target\": \"{target}\", \"flag\": \"{featureKey}\"}} and the default variation {defaultValue} is being returned");
         }
 
         private bool checkPreRequisite(FeatureConfig parentFeatureConfig, dto.Target target)
@@ -260,14 +263,14 @@ namespace io.harness.cfsdk.client.api
                     // check exclude list
                     if (segment.Excluded != null && segment.Excluded.Any(t => t.Identifier.Equals(target.Identifier)))
                     {
-                        Log.Debug($"Target {target.Name} excluded from segment {segment.Name} via exclude list");
+                        logger.LogDebug($"Target {target.Name} excluded from segment {segment.Name} via exclude list");
                         return false;
                     }
 
                     // check include list
                     if (segment.Included != null && segment.Included.Any(t => t.Identifier.Equals(target.Identifier)))
                     {
-                        Log.Debug($"Target {target.Name} included in segment {segment.Name} via include list");
+                        logger.LogDebug($"Target {target.Name} included in segment {segment.Name} via include list");
                         return true;
                     }
 

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using io.harness.cfsdk.client.api.rules;
-using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.HarnessOpenAPIService;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -121,7 +120,12 @@ namespace io.harness.cfsdk.client.api
 
         private void logEvaluatiionFailureError(FeatureConfigKind kind, string featureKey, dto.Target target, string defaultValue)
         {
-            logger.LogWarning($"SDKCODE(eval:6001): Failed to evaluate {kind} variation for {{ \"target\": \"{target}\", \"flag\": \"{featureKey}\"}} and the default variation {defaultValue} is being returned");
+            if (logger.IsEnabled(LogLevel.Warning))
+            {
+                logger.LogWarning(
+                    "SDKCODE(eval:6001): Failed to evaluate {kind} variation for {targetId}, flag {featureId} and the default variation {defaultValue} is being returned",
+                    kind, target.Identifier, featureKey, defaultValue);
+            }
         }
 
         private bool checkPreRequisite(FeatureConfig parentFeatureConfig, dto.Target target)
@@ -263,14 +267,23 @@ namespace io.harness.cfsdk.client.api
                     // check exclude list
                     if (segment.Excluded != null && segment.Excluded.Any(t => t.Identifier.Equals(target.Identifier)))
                     {
-                        logger.LogDebug($"Target {target.Name} excluded from segment {segment.Name} via exclude list");
+                        if (logger.IsEnabled(LogLevel.Debug))
+                        {
+                            logger.LogDebug("Target {targetName} excluded from segment {segmentName} via exclude list",
+                                target.Name, segment.Name);
+                        }
                         return false;
                     }
 
                     // check include list
                     if (segment.Included != null && segment.Included.Any(t => t.Identifier.Equals(target.Identifier)))
                     {
-                        logger.LogDebug($"Target {target.Name} included in segment {segment.Name} via include list");
+                        if (logger.IsEnabled(LogLevel.Debug))
+                        {
+                            logger.LogDebug("Target {targetName} included in segment {segmentName} via include list",
+                                target.Name, segment.Name);
+                        }
+
                         return true;
                     }
 

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -77,7 +77,7 @@ namespace io.harness.cfsdk.client.api
                 intervalMs = 60000;
             }
 
-            logger.LogDebug($"SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}");
+            logger.LogDebug("SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}", intervalMs);
             // start timer which will initiate periodic reading of flags and segments
             pollTimer = new Timer(OnTimedEventAsync, null, 0, intervalMs);
         }
@@ -105,7 +105,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch (CfClientException ex)
             {
-                logger.LogError(ex,$"Exception was raised when fetching flags data with the message {ex.Message}");
+                logger.LogError(ex,"Exception was raised when fetching flags data with the message {reason}", ex.Message);
                 throw;
             }
         }
@@ -123,7 +123,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch (CfClientException ex)
             {
-                logger.LogError(ex, $"Exception was raised when fetching segments data with the message {ex.Message}");
+                logger.LogError(ex, "Exception was raised when fetching segments data with the message {reason}", ex.Message);
                 throw;
             }
         }
@@ -141,7 +141,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch(Exception ex)
             {
-                logger.LogWarning(ex,$"Polling failed with error: {ex.Message}. Will retry in {config.pollIntervalInSeconds}");
+                logger.LogWarning(ex,"Polling failed with error: {reason}. Will retry in {pollIntervalInSeconds}", ex.Message, config.pollIntervalInSeconds);
                 callback.OnPollError(ex.Message);
             }
         }

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using io.harness.cfsdk.client.connector;
 using io.harness.cfsdk.HarnessOpenAPIService;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace io.harness.cfsdk.client.api
 {
@@ -43,6 +43,7 @@ namespace io.harness.cfsdk.client.api
     /// </summary>
     internal class PollingProcessor : IPollingProcessor
     {
+        private readonly ILogger<PollingProcessor> logger;
         private IConnector connector;
         private IRepository repository;
         private IPollCallback callback;
@@ -51,13 +52,14 @@ namespace io.harness.cfsdk.client.api
         private bool isInitialized = false;
         private SemaphoreSlim readyEvent;
 
-        public PollingProcessor(IConnector connector, IRepository repository, Config config, IPollCallback callback)
+        public PollingProcessor(IConnector connector, IRepository repository, Config config, IPollCallback callback, ILoggerFactory loggerFactory)
         {
             this.callback = callback;
             this.repository = repository;
             this.connector = connector;
             this.config = config;
             this.readyEvent = new SemaphoreSlim(0, 3);
+            this.logger = loggerFactory.CreateLogger<PollingProcessor>();
         }
         public async Task<bool> ReadyAsync()
         {
@@ -71,17 +73,17 @@ namespace io.harness.cfsdk.client.api
 
             if (intervalMs < 60000)
             {
-                Log.Warning("Poll interval cannot be less than 60 seconds");
+                logger.LogWarning("Poll interval cannot be less than 60 seconds");
                 intervalMs = 60000;
             }
 
-            Log.Debug($"SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}");
+            logger.LogDebug($"SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}");
             // start timer which will initiate periodic reading of flags and segments
             pollTimer = new Timer(OnTimedEventAsync, null, 0, intervalMs);
         }
         public void Stop()
         {
-            Log.Debug("SDKCODE(poll:4001): Polling stopped");
+            logger.LogDebug("SDKCODE(poll:4001): Polling stopped");
             // stop timer
             if (pollTimer == null) return;
             pollTimer.Dispose();
@@ -92,9 +94,9 @@ namespace io.harness.cfsdk.client.api
         {
             try
             {
-                Log.Debug("Fetching flags started");
+                logger.LogDebug("Fetching flags started");
                 var flags = await this.connector.GetFlags();
-                Log.Debug("Fetching flags finished");
+                logger.LogDebug("Fetching flags finished");
                 foreach (var item in flags)
                 {
                     repository.SetFlag(item.Feature, item);
@@ -103,8 +105,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch (CfClientException ex)
             {
-                Log.Error($"Exception was raised when fetching flags data with the message {ex.Message}");
-                Log.Error(ex.StackTrace);
+                logger.LogError(ex,$"Exception was raised when fetching flags data with the message {ex.Message}");
                 throw;
             }
         }
@@ -112,9 +113,9 @@ namespace io.harness.cfsdk.client.api
         {
             try
             {
-                Log.Debug("Fetching segments started");
+                logger.LogDebug("Fetching segments started");
                 IEnumerable<Segment> segments = await connector.GetSegments();
-                Log.Debug("Fetching segments finished");
+                logger.LogDebug("Fetching segments finished");
                 foreach (Segment item in segments)
                 {
                     repository.SetSegment(item.Identifier, item);
@@ -122,8 +123,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch (CfClientException ex)
             {
-                Log.Error($"Exception was raised when fetching segments data with the message {ex.Message}");
-                Log.Error(ex.StackTrace);
+                logger.LogError(ex, $"Exception was raised when fetching segments data with the message {ex.Message}");
                 throw;
             }
         }
@@ -131,7 +131,7 @@ namespace io.harness.cfsdk.client.api
         {
             try
             {
-                Log.Debug("Running polling iteration");
+                logger.LogDebug("Running polling iteration");
                 await Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() });
 
                 if (isInitialized) return;
@@ -141,7 +141,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch(Exception ex)
             {
-                Log.Warning($"Polling failed with error: {ex.Message}. Will retry in {config.pollIntervalInSeconds}");
+                logger.LogWarning(ex,$"Polling failed with error: {ex.Message}. Will retry in {config.pollIntervalInSeconds}");
                 callback.OnPollError(ex.Message);
             }
         }

--- a/client/api/Repository.cs
+++ b/client/api/Repository.cs
@@ -86,11 +86,11 @@ namespace io.harness.cfsdk.client.api
             string key = FlagKey(identifier);
             if (store != null)
             {
-                logger.LogDebug($"Flag {identifier} successfully deleted from store");
+                logger.LogDebug("Flag {identifier} successfully deleted from store", identifier);
                 store.Delete(key);
             }
             this.cache.Delete(key);
-            logger.LogDebug($"Flag {identifier} successfully deleted from cache");
+            logger.LogDebug("Flag {identifier} successfully deleted from cache", identifier);
             if (this.callback != null)
             {
                 this.callback.OnFlagDeleted(identifier);
@@ -102,11 +102,11 @@ namespace io.harness.cfsdk.client.api
             string key = SegmentKey(identifier);
             if (store != null)
             {
-                logger.LogDebug($"Segment {identifier} successfully deleted from store");
+                logger.LogDebug("Segment {identifier} successfully deleted from store", identifier);
                 store.Delete(key);
             }
             this.cache.Delete(key);
-            logger.LogDebug($"Segment {identifier} successfully deleted from cache");
+            logger.LogDebug("Segment {identifier} successfully deleted from cache", identifier);
             if (this.callback != null)
             {
                 this.callback.OnSegmentDeleted(identifier);
@@ -146,7 +146,7 @@ namespace io.harness.cfsdk.client.api
             // or if version is equal 0 (or doesn't exist)
             if( current != null && featureConfig.Version != 0 && current.Version >= featureConfig.Version )
             {
-                logger.LogDebug($"Flag {identifier} already exists");
+                logger.LogDebug("Flag {identifier} already exists", identifier);
                 return;
             }
 
@@ -164,7 +164,7 @@ namespace io.harness.cfsdk.client.api
             // or if version is equal 0 (or doesn't exist)
             if (current != null && segment.Version != 0 && current.Version >= segment.Version)
             {
-                logger.LogDebug($"Segment {identifier} already exists");
+                logger.LogDebug("Segment {identifier} already exists", identifier);
                 return;
             }
 
@@ -180,12 +180,12 @@ namespace io.harness.cfsdk.client.api
         {
             if (this.store == null)
             {
-                logger.LogDebug($"Item {identifier} successfully cached");
+                logger.LogDebug("Item {identifier} successfully cached, identifier", identifier);
                 cache.Set(key, value);
             }
             else
             {
-                logger.LogDebug($"Item {identifier} successfully stored and cache invalidated");
+                logger.LogDebug("Item {identifier} successfully stored and cache invalidated", identifier);
                 store.Set(key, value);
                 cache.Delete(key);
             }

--- a/client/api/UpdateProcessor.cs
+++ b/client/api/UpdateProcessor.cs
@@ -103,7 +103,7 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch(Exception ex)
                 {
-                    logger.LogError(ex,$"Error processing flag: {message.Identifier} event: {message.Event}.");
+                    logger.LogError(ex,"Error processing flag: {identifier} event: {event}.", message.Identifier, message.Event);
                 }
             }
             else if (message.Domain.Equals("target-segment"))
@@ -122,7 +122,7 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch(Exception ex)
                 {
-                    logger.LogError(ex,$"Error processing segment: {message.Identifier} event: {message.Event}.");
+                    logger.LogError(ex,"Error processing segment: {identifier} event: {event}.",  message.Identifier, message.Event);
                 }
             }
         }

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -68,7 +68,7 @@ namespace io.harness.cfsdk.client.api.analytics
 
             if (cacheSize > bufferSize)
             {
-                logger.LogWarning("Metric frequency map exceeded buffer size ({0} > {1}), force flushing", cacheSize, bufferSize);
+                logger.LogWarning("Metric frequency map exceeded buffer size ({cacheSize} > {bufferSize}), force flushing", cacheSize, bufferSize);
 
                 // If the map is starting to grow too much then push the metrics now and reset the counters
                 SendMetrics();

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -48,6 +48,7 @@ namespace io.harness.cfsdk.client.api.analytics
                 this.timer.AutoReset = true;
                 this.timer.Enabled = true;
                 this.timer.Start();
+                logger.LogInformation("SDKCODE(metric:7000): Metrics thread started");
             }
         }
 
@@ -58,6 +59,7 @@ namespace io.harness.cfsdk.client.api.analytics
             {
                 this.timer.Stop();
                 this.timer = null;
+                logger.LogInformation("SDKCODE(metric:7001): Metrics thread exited");
             }
         }
 

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -3,17 +3,19 @@ using io.harness.cfsdk.client.connector;
 using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.HarnessOpenAPIService;
 using io.harness.cfsdk.HarnessOpenMetricsAPIService;
-using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace io.harness.cfsdk.client.api.analytics
 {
     internal class AnalyticsPublisherService
     {
+        private readonly ILogger<AnalyticsPublisherService> logger;
+
         private static string FEATURE_NAME_ATTRIBUTE = "featureName";
         private static string VARIATION_VALUE_ATTRIBUTE = "featureValue";
         private static string VARIATION_IDENTIFIER_ATTRIBUTE = "variationIdentifier";
@@ -26,16 +28,15 @@ namespace io.harness.cfsdk.client.api.analytics
         private static string SDK_LANGUAGE = "SDK_LANGUAGE";
         private static string SDK_VERSION = "SDK_VERSION";
 
-
-        private string sdkVersion = Assembly.GetExecutingAssembly().GetName().ToString();
-
+        private readonly string sdkVersion = Assembly.GetExecutingAssembly().GetName().ToString();
         private AnalyticsCache analyticsCache;
         private IConnector connector;
 
-        public AnalyticsPublisherService(IConnector connector, AnalyticsCache analyticsCache)
+        public AnalyticsPublisherService(IConnector connector, AnalyticsCache analyticsCache, ILoggerFactory loggerFactory)
         {
             this.analyticsCache = analyticsCache;
             this.connector = connector;
+            this.logger = loggerFactory.CreateLogger<AnalyticsPublisherService>();
         }
 
         public void sendDataAndResetCache()
@@ -50,20 +51,20 @@ namespace io.harness.cfsdk.client.api.analytics
                     if ((metrics.MetricsData != null && metrics.MetricsData.Count >0)
                         || (metrics.TargetData != null && metrics.TargetData.Count > 0))
                     {
-                        Log.Debug("Sending analytics data :{@a}", metrics);
+                        logger.LogDebug("Sending analytics data :{@a}", metrics);
                         connector.PostMetrics(metrics);
                     }
 
                     stagingTargetSet.ToList().ForEach(element => globalTargetSet.Add(element));
                     stagingTargetSet.Clear();
-                    Log.Debug("Successfully sent analytics data to the server");
+                    logger.LogDebug("Successfully sent analytics data to the server");
                     analyticsCache.resetCache();
                 }
                 catch (CfClientException ex)
                 {
                     // Clear the set because the cache is only invalidated when there is no
                     // exception, so the targets will reappear in the next iteration
-                    Log.Error($"SDKCODE(stream:7002): Posting metrics failed, reason: {ex.Message}");
+                    logger.LogError($"SDKCODE(stream:7002): Posting metrics failed, reason: {ex.Message}");
                 }
             }
         }

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -64,7 +64,7 @@ namespace io.harness.cfsdk.client.api.analytics
                 {
                     // Clear the set because the cache is only invalidated when there is no
                     // exception, so the targets will reappear in the next iteration
-                    logger.LogError($"SDKCODE(stream:7002): Posting metrics failed, reason: {ex.Message}");
+                    logger.LogError("SDKCODE(stream:7002): Posting metrics failed, reason: {reason}", ex.Message);
                 }
             }
         }

--- a/client/cache/FileMapStore.cs
+++ b/client/cache/FileMapStore.cs
@@ -3,20 +3,27 @@ using System.Linq;
 using System.IO;
 using System.Collections.Generic;
 using io.harness.cfsdk.client.cache;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using Serilog;
 
 namespace io.harness.cfsdk.client.api
 {
     public class FileMapStore : IStore
     {
+        private readonly ILogger<FileMapStore> logger;
         private string storeName;
-        public FileMapStore(string name)
+
+        public FileMapStore(string name, ILoggerFactory loggerFactory)
         {
+            logger = loggerFactory.CreateLogger<FileMapStore>();
             storeName = name;
             Directory.CreateDirectory(name);
             Array.ForEach(Directory.EnumerateFiles(name).ToArray(), f => File.Delete(f));
+        }
+
+        public FileMapStore(string name) : this(name, LoggerFactory.Create(builder => { builder.AddConsole(); }))
+        {
         }
 
         public void Close()
@@ -43,7 +50,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch( Exception ex)
             {
-                Log.Error("Failure to deserialize data from file storage", ex);
+                logger.LogError(ex, "Failure to deserialize data from file storage");
                 return null;
             }
         }

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -85,7 +85,7 @@ namespace io.harness.cfsdk.client.connector
                             continue;
                         }
 
-                        logger.LogInformation($"SDKCODE(stream:5002): SSE event received {message}");
+                        logger.LogInformation("SDKCODE(stream:5002): SSE event received {message}", message);
 
                         // parse message
                         var jsonMessage = JObject.Parse("{" + message + "}");
@@ -104,7 +104,7 @@ namespace io.harness.cfsdk.client.connector
             }
             catch (Exception e)
             {
-                logger.LogError(e, $"EventSource service threw an error: {e.Message} Retrying in {config.pollIntervalInSeconds}");
+                logger.LogError(e, "EventSource service threw an error: {reason} Retrying in {pollIntervalInSeconds}", e.Message, config.pollIntervalInSeconds);
                 Debug.WriteLine(e.ToString());
             }
             finally

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -6,25 +6,27 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using io.harness.cfsdk.client.api;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
-using Serilog;
 
 namespace io.harness.cfsdk.client.connector
 {
     public class EventSource : IService
     {
+        private readonly ILogger<EventSource> logger;
         private readonly string url;
         private readonly Config config;
         private readonly HttpClient httpClient;
         private readonly IUpdateCallback callback;
         private const int ReadTimeoutMs = 60_000;
 
-        public EventSource(HttpClient httpClient, string url, Config config, IUpdateCallback callback)
+        public EventSource(HttpClient httpClient, string url, Config config, IUpdateCallback callback, ILoggerFactory loggerFactory)
         {
             this.httpClient = httpClient;
             this.url = url;
             this.config = config;
             this.callback = callback;
+            this.logger = loggerFactory.CreateLogger<EventSource>();
         }
 
         public void Close()
@@ -39,7 +41,7 @@ namespace io.harness.cfsdk.client.connector
 
         public void Stop()
         {
-            Log.Debug("Stopping EventSource service.");
+            logger.LogDebug("Stopping EventSource service.");
         }
 
         private string ReadLine(Stream stream, int timeoutMs)
@@ -69,7 +71,7 @@ namespace io.harness.cfsdk.client.connector
             try
             {
 
-                Log.Debug("Starting EventSource service.");
+                logger.LogDebug("Starting EventSource service.");
                 using (Stream stream = await this.httpClient.GetStreamAsync(url))
                 {
                     callback.OnStreamConnected();
@@ -79,11 +81,11 @@ namespace io.harness.cfsdk.client.connector
                     {
                         if (!message.Contains("domain"))
                         {
-                            Log.Verbose("Received event source heartbeat");
+                            logger.LogTrace("Received event source heartbeat");
                             continue;
                         }
 
-                        Log.Information($"SDKCODE(stream:5002): SSE event received {message}");
+                        logger.LogInformation($"SDKCODE(stream:5002): SSE event received {message}");
 
                         // parse message
                         var jsonMessage = JObject.Parse("{" + message + "}");
@@ -102,7 +104,7 @@ namespace io.harness.cfsdk.client.connector
             }
             catch (Exception e)
             {
-                Log.Error($"EventSource service threw an error: {e.Message} Retrying in {config.pollIntervalInSeconds}", e);
+                logger.LogError(e, $"EventSource service threw an error: {e.Message} Retrying in {config.pollIntervalInSeconds}");
                 Debug.WriteLine(e.ToString());
             }
             finally

--- a/client/connector/FileWatcher.cs
+++ b/client/connector/FileWatcher.cs
@@ -1,23 +1,29 @@
 ﻿using System;
 using System.IO;
 using io.harness.cfsdk.client.api;
-using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace io.harness.cfsdk.client.connector
 {
     public class FileWatcher : IDisposable, IService
     {
+        private readonly ILogger<FileWatcher> logger;
         private readonly string domain;
         private readonly string path;
         private readonly IUpdateCallback callback;
 
         private FileSystemWatcher watcher;
 
-        public FileWatcher(string domain, string path, IUpdateCallback callback)
+        public FileWatcher(string domain, string path, IUpdateCallback callback, ILoggerFactory loggerFactory)
         {
             this.domain = domain;
             this.callback = callback;
             this.path = path;
+            this.logger = loggerFactory.CreateLogger<FileWatcher>();
+        }
+
+        public FileWatcher(string domain, string path, IUpdateCallback callback) : this(domain, path, callback, LoggerFactory.Create(builder => { builder.AddConsole(); }))
+        {
         }
 
         private void Watcher_Deleted(object sender, FileSystemEventArgs e)
@@ -62,7 +68,7 @@ namespace io.harness.cfsdk.client.connector
             }
             catch(Exception ex)
             {
-                Log.Error($"Error creating fileWatcher at {path}", ex);
+                logger.LogError(ex, $"Error creating fileWatcher at {path}");
             }
         }
 

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -187,13 +187,13 @@ namespace io.harness.cfsdk.client.connector
                     logger.LogInformation("SDKCODE(metric:7001): Metrics thread exited");
                 }
                 catch (ApiException ex) {
-                    logger.LogWarning(ex, $"SDKCODE(metric:7002): Posting metrics failed, reason: {ex.Message}");
+                    logger.LogWarning(ex, "SDKCODE(metric:7002): Posting metrics failed, reason: {reason}", ex.Message);
                 }
 
                 var endTime = DateTime.Now;
                 if ((endTime - startTime).TotalMilliseconds > config.MetricsServiceAcceptableDuration)
                 {
-                    logger.LogWarning($"Metrics post duration exceeded allowable=[{endTime - startTime}]");
+                    logger.LogWarning("Metrics post duration exceeded allowable=[{allowableTime}]", endTime - startTime);
                 }
 
                 return null;
@@ -202,7 +202,7 @@ namespace io.harness.cfsdk.client.connector
         public async Task<string> Authenticate()
         {
             if (string.IsNullOrWhiteSpace(apiKey)) {
-                var errorMsg = $"SDKCODE(init:1002):The SDK has failed to initialize due to a missing or empty API key.";
+                var errorMsg = "SDKCODE(init:1002):The SDK has failed to initialize due to a missing or empty API key.";
                 logger.LogError(errorMsg);
                 throw new CfClientException(errorMsg);
             }
@@ -249,11 +249,11 @@ namespace io.harness.cfsdk.client.connector
             }
             catch (ApiException ex)
             {
-                logger.LogError(ex, $"SDKCODE(init:1001):The SDK has failed to initialize due to the following authentication error: {ex.Message}");
+                logger.LogError(ex, "SDKCODE(init:1001):The SDK has failed to initialize due to the following authentication error: {reason}", ex.Message);
 
                 if (ex.StatusCode == (int)HttpStatusCode.Unauthorized || ex.StatusCode == (int)HttpStatusCode.Forbidden)
                 {
-                    var errorMsg = $"SDKCODE(init:1001):The SDK has failed to initialize due to the following authentication error: Invalid apiKey {apiKey}. Defaults will be served.";
+                    var errorMsg = "SDKCODE(init:1001):The SDK has failed to initialize due to the following authentication error: Invalid apiKey. Defaults will be served.";
                     logger.LogError(errorMsg);
                     throw new CfClientException(errorMsg);
                 }

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -182,9 +182,7 @@ namespace io.harness.cfsdk.client.connector
                     BaseUrl = config.EventUrl
                 };
                 try {
-                    logger.LogInformation("SDKCODE(metric:7000): Metrics thread started");
                     await client.MetricsAsync(environment, metrics, cancelToken.Token);
-                    logger.LogInformation("SDKCODE(metric:7001): Metrics thread exited");
                 }
                 catch (ApiException ex) {
                     logger.LogWarning(ex, "SDKCODE(metric:7002): Posting metrics failed, reason: {reason}", ex.Message);

--- a/client/connector/JsonContractResolver.cs
+++ b/client/connector/JsonContractResolver.cs
@@ -25,7 +25,7 @@ namespace io.harness.cfsdk.client.connector
             this.logger = loggerFactory.CreateLogger<JsonContractResolver>();
         }
 
-        protected override JsonProperty CreateProperty(System.Reflection.MemberInfo member, MemberSerialization memberSerialization)
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
             OverrideRequiredProperty(ref property);
@@ -35,7 +35,7 @@ namespace io.harness.cfsdk.client.connector
         protected override JsonObjectContract CreateObjectContract(Type objectType)
         {
             var contract = base.CreateObjectContract(objectType);
-            contract.ItemRequired = Required.Default;
+            OverrideRequiredProperty(ref contract);
             return contract;
         }
 
@@ -50,7 +50,7 @@ namespace io.harness.cfsdk.client.connector
         {
             if (property.NullValueHandling != NullValueHandling.Ignore ||
                 property.Required != Required.DisallowNull) return;
-            logger.LogDebug($"Changing JSON property '{property.PropertyName}' from Required.DisallowNull to Required.Default");
+            logger.LogDebug("Changing JSON property '{PropertyName}' from Required.DisallowNull to Required.Default", property.PropertyName);
             property.Required = Required.Default;
         }
         
@@ -58,7 +58,7 @@ namespace io.harness.cfsdk.client.connector
         {
             if (contract.ItemNullValueHandling != NullValueHandling.Ignore ||
                 contract.ItemRequired != Required.DisallowNull) return;
-            logger.LogDebug($"Changing JSON object contract '{contract}' from Required.DisallowNull to Required.Default");
+            logger.LogDebug("Changing JSON object contract '{contract}' from Required.DisallowNull to Required.Default", contract);
             contract.ItemRequired = Required.Default;
         }
     }

--- a/client/connector/JsonContractResolver.cs
+++ b/client/connector/JsonContractResolver.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using Serilog;
 
 namespace io.harness.cfsdk.client.connector
 {
@@ -16,8 +16,15 @@ namespace io.harness.cfsdk.client.connector
     /// https://github.com/RicoSuter/NSwag/issues/850
     /// https://www.newtonsoft.com/json/help/html/t_newtonsoft_json_required.htm
     /// </summary>
-    class JsonContractResolver : DefaultContractResolver
+    internal class JsonContractResolver : DefaultContractResolver
     {
+        private readonly ILogger<JsonContractResolver> logger;
+
+        internal JsonContractResolver(ILoggerFactory loggerFactory)
+        {
+            this.logger = loggerFactory.CreateLogger<JsonContractResolver>();
+        }
+
         protected override JsonProperty CreateProperty(System.Reflection.MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);
@@ -43,7 +50,7 @@ namespace io.harness.cfsdk.client.connector
         {
             if (property.NullValueHandling != NullValueHandling.Ignore ||
                 property.Required != Required.DisallowNull) return;
-            Log.Debug($"Changing JSON property '{property.PropertyName}' from Required.DisallowNull to Required.Default");
+            logger.LogDebug($"Changing JSON property '{property.PropertyName}' from Required.DisallowNull to Required.Default");
             property.Required = Required.Default;
         }
         
@@ -51,7 +58,7 @@ namespace io.harness.cfsdk.client.connector
         {
             if (contract.ItemNullValueHandling != NullValueHandling.Ignore ||
                 contract.ItemRequired != Required.DisallowNull) return;
-            Log.Debug($"Changing JSON object contract '{contract}' from Required.DisallowNull to Required.Default");
+            logger.LogDebug($"Changing JSON object contract '{contract}' from Required.DisallowNull to Required.Default");
             contract.ItemRequired = Required.Default;
         }
     }

--- a/client/connector/LocalConnector.cs
+++ b/client/connector/LocalConnector.cs
@@ -5,20 +5,27 @@ using io.harness.cfsdk.client.api;
 using io.harness.cfsdk.HarnessOpenAPIService;
 using io.harness.cfsdk.HarnessOpenMetricsAPIService;
 using Newtonsoft.Json;
-using Serilog;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace io.harness.cfsdk.client.connector
 {
     public class LocalConnector : IConnector
     {
+        private readonly ILogger<LocalConnector> logger;
         private string flagPath;
         private string segmentPath;
         private string metricPath;
         private string source;
-        public LocalConnector(string source)
+
+        public LocalConnector(string source) : this(source, LoggerFactory.Create(builder => { builder.AddConsole(); }))
         {
+        }
+
+        public LocalConnector(string source, ILoggerFactory loggerFactory)
+        {
+            this.logger = loggerFactory.CreateLogger<LocalConnector>();
             this.source = source;
 
             this.flagPath = Path.Combine(source, "flags");
@@ -61,7 +68,7 @@ namespace io.harness.cfsdk.client.connector
             }
             catch (Exception ex)
             {
-                Log.Error("Error accessing feature files.", ex);
+                logger.LogError(ex, "Error accessing feature files.");
             }
             return Task.FromResult((IEnumerable<FeatureConfig>)features);
         }
@@ -84,7 +91,7 @@ namespace io.harness.cfsdk.client.connector
             }
             catch(Exception ex)
             {
-                Log.Error("Error accessing segment files.", ex);
+                logger.LogError(ex, "Error accessing segment files.");
             }
             return Task.FromResult((IEnumerable<Segment>)segments);
         }

--- a/client/polling/ShortTermPolling.cs
+++ b/client/polling/ShortTermPolling.cs
@@ -1,32 +1,35 @@
-﻿using Serilog;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
 using System.Timers;
+using Microsoft.Extensions.Logging;
 
 namespace io.harness.cfsdk.client.polling
 {
     public class ShortTermPolling : IEvaluationPolling
     {
+        private readonly ILogger<ShortTermPolling> logger;
         private static int MINIMUM_POLLING_INTERVAL = 10000;
         private long pollingInterval;
         private Timer timer;
 
-        public ShortTermPolling(int time)
+        public ShortTermPolling(int time) : this(time, LoggerFactory.Create(builder => { builder.AddConsole(); }))
+        {
+        }
+
+        public ShortTermPolling(int time, ILoggerFactory loggerFactory)
         {
             pollingInterval = Math.Max(time, MINIMUM_POLLING_INTERVAL);
-
+            logger = loggerFactory.CreateLogger<ShortTermPolling>();
         }
 
         public void start(Action<object, ElapsedEventArgs> runnable)
         {
             if (timer != null)
             {
-                Log.Debug("POLLING timer - stopping before start");
+                logger.LogDebug("POLLING timer - stopping before start");
                 timer.Stop();
                 timer.Dispose();
             }
-            Log.Debug("POLLING timer - scheduling new one");
+            logger.LogDebug("POLLING timer - scheduling new one");
             timer = new Timer(pollingInterval);
             timer.Elapsed += new ElapsedEventHandler(runnable);
             timer.AutoReset = true;
@@ -38,11 +41,11 @@ namespace io.harness.cfsdk.client.polling
         {
             if (timer != null)
             {
-                Log.Debug("POLLING timer - stopping on exit");
+                logger.LogDebug("POLLING timer - stopping on exit");
                 timer.Stop();
                 timer.Dispose();
             }
-            Log.Debug("POLLING timer - stoped");
+            logger.LogDebug("POLLING timer - stoped");
         }
     }
 }

--- a/examples/getting_started/Program.cs
+++ b/examples/getting_started/Program.cs
@@ -35,7 +35,7 @@ namespace getting_started
            // Loop forever reporting the state of the flag
             while (true)
             {
-                bool resultBool = CfClient.Instance.boolVariation(flagName, target, false);
+                bool resultBool = client.boolVariation(flagName, target, false);
                 Console.WriteLine("Flag variation " + resultBool);
                 Thread.Sleep(10 * 1000);
             }

--- a/examples/getting_started/Program.cs
+++ b/examples/getting_started/Program.cs
@@ -23,7 +23,7 @@ namespace getting_started
 
             // Create a feature flag client
             var client = new CfClient(apiKey, Config.Builder().LoggerFactory(loggerFactory).Build());
-            client.InitializeAndWait();
+            client.InitializeAndWait().Wait();
 
             // Create a target (different targets can get different results based on rules)
             Target target = Target.builder()

--- a/examples/getting_started/Program.cs
+++ b/examples/getting_started/Program.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.client.api;
 using System.Threading;
+using Serilog;
+using Serilog.Extensions.Logging;
 
 namespace getting_started
 {
@@ -13,13 +15,20 @@ namespace getting_started
 
         static void Main(string[] args)
         {
+            var loggerFactory = new SerilogLoggerFactory(
+                new LoggerConfiguration()
+                    .MinimumLevel.Information()
+                    .WriteTo.Console()
+                    .CreateLogger());
+
             // Create a feature flag client
-            CfClient.Instance.Initialize(apiKey, Config.Builder().Build());
+            var client = new CfClient(apiKey, Config.Builder().LoggerFactory(loggerFactory).Build());
+            client.InitializeAndWait();
 
             // Create a target (different targets can get different results based on rules)
             Target target = Target.builder()
-                            .Name("Harness_Target_1")
-                            .Identifier("HT_1")
+                            .Name("DotNET SDK")
+                            .Identifier("dotnetsdk")
                             .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
                             .build();
 

--- a/examples/getting_started/Program.cs
+++ b/examples/getting_started/Program.cs
@@ -36,7 +36,7 @@ namespace getting_started
             while (true)
             {
                 bool resultBool = client.boolVariation(flagName, target, false);
-                Console.WriteLine("Flag variation " + resultBool);
+                Console.WriteLine($"Flag '{flagName}' = " + resultBool);
                 Thread.Sleep(10 * 1000);
             }
         }

--- a/examples/getting_started/Program.cs
+++ b/examples/getting_started/Program.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.client.api;
 using System.Threading;
-using Serilog;
 
 namespace getting_started
 {

--- a/examples/getting_started/getting_started.csproj
+++ b/examples/getting_started/getting_started.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="ff-dotnet-server-sdk" Version="1.2.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0"/>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 

--- a/examples/getting_started/getting_started.csproj
+++ b/examples/getting_started/getting_started.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RestoreSources>$(RestoreSources);https://api.nuget.org/v3/index.json</RestoreSources>
 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ff-dotnet-server-sdk" Version="1.1.*" />
+    <PackageReference Include="ff-dotnet-server-sdk" Version="1.2.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -35,7 +35,6 @@
 
     <ItemGroup>
         <PackageReference Include="Disruptor" Version="4.0.0" />
-        <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
         <PackageReference Include="murmurhash" Version="1.0.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
@@ -49,6 +48,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0"/>
     </ItemGroup>
 

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.1.10</Version>
+        <Version>1.2.0</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.1.10</PackageVersion>
-        <AssemblyVersion>1.1.10</AssemblyVersion>
+        <PackageVersion>1.2.0</PackageVersion>
+        <AssemblyVersion>1.2.0</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2023</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
@@ -48,8 +48,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <!-- The SDK must be built with .NET 7 however we must also keep compatibility with .NET 5/6 hence SupportedOSPlatformVersion=9 below -->
         <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
         <LangVersion>9.0</LangVersion>
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
@@ -11,7 +13,7 @@
         <PackageVersion>1.1.10</PackageVersion>
         <AssemblyVersion>1.1.10</AssemblyVersion>
         <Authors>support@harness.io</Authors>
-        <Copyright>Copyright © 2023 </Copyright>
+        <Copyright>Copyright © 2023</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
         <PackageLicenseUrl>https://github.com/drone/ff-dotnet-server-sdk/blob/main/LICENSE</PackageLicenseUrl>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -36,7 +38,6 @@
         <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
         <PackageReference Include="murmurhash" Version="1.0.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
@@ -48,7 +49,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/ff-server-sdk-test/AuthService.cs
+++ b/tests/ff-server-sdk-test/AuthService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using io.harness.cfsdk.client.api;
 using io.harness.cfsdk.client.connector;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 
@@ -17,6 +18,8 @@ namespace ff_server_sdk_test
     [TestFixture]
     public class InnerClient
     {
+        private static readonly ILoggerFactory _loggerFactory = LoggerFactory.Create(builder => { builder.AddConsole(); });
+
         [Test]
         public async Task shouldOnlyAuthenticateOnceIfSuccessful()
         {
@@ -26,7 +29,7 @@ namespace ff_server_sdk_test
                 .Setup(a => a.Authenticate())
                 .ReturnsAsync("Done");
             // Act
-            var a = new AuthService(mockConnector.Object, new Config { pollIntervalInSeconds = 1 }, new FakeAuth());
+            var a = new AuthService(mockConnector.Object, new Config { pollIntervalInSeconds = 1 }, new FakeAuth(), _loggerFactory);
             a.Start();
             
             // Verify
@@ -46,7 +49,7 @@ namespace ff_server_sdk_test
                 .ReturnsAsync("DONE");
             
             // Act
-            var a = new AuthService(mockConnector.Object, new Config { pollIntervalInSeconds = 1 }, new FakeAuth());
+            var a = new AuthService(mockConnector.Object, new Config { pollIntervalInSeconds = 1 }, new FakeAuth(), _loggerFactory);
             a.Start();
             
             // Verify
@@ -66,7 +69,7 @@ namespace ff_server_sdk_test
                 .ReturnsAsync("DONE");
             
             // Act
-            var a = new AuthService(mockConnector.Object, new Config { pollIntervalInSeconds = 1, maxAuthRetries = 1}, new FakeAuth());
+            var a = new AuthService(mockConnector.Object, new Config { pollIntervalInSeconds = 1, maxAuthRetries = 1}, new FakeAuth(), _loggerFactory);
             a.Start();
             
             // Verify

--- a/tests/ff-server-sdk-test/EvaluatorTest.cs
+++ b/tests/ff-server-sdk-test/EvaluatorTest.cs
@@ -5,6 +5,7 @@ using System.IO;
 using io.harness.cfsdk.client.api;
 using io.harness.cfsdk.client.cache;
 using io.harness.cfsdk.HarnessOpenAPIService;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -33,7 +34,7 @@ namespace ff_server_sdk_test
             Variation variation)
         {
             var targetName = target != null ? target.Name : "_no_target";
-            Serilog.Log.Information($"processEvaluation {featureConfig.Feature}, {targetName}, {variation.Value} ");
+            Console.WriteLine($"processEvaluation {featureConfig.Feature}, {targetName}, {variation.Value} ");
         }
     }
 
@@ -51,10 +52,11 @@ namespace ff_server_sdk_test
         // Initial Evaluator test setup
         static EvaluatorTest()
         {
+            var loggerFactory = LoggerFactory.Create(builder => { builder.AddConsole(); });
             var listener = new EvaluatorListener();
             cache = new FeatureSegmentCache();
-            repository = new StorageRepository(cache, null, null);
-            evaluator = new Evaluator(repository, listener);
+            repository = new StorageRepository(cache, null, null, loggerFactory);
+            evaluator = new Evaluator(repository, listener, loggerFactory);
         }
 
         private static void LoadSegments(List<Segment> segments)

--- a/tests/ff-server-sdk-test/HarnessConnectorTest.cs
+++ b/tests/ff-server-sdk-test/HarnessConnectorTest.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using io.harness.cfsdk.client.api;
 using io.harness.cfsdk.client.connector;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
@@ -16,6 +17,7 @@ namespace ff_server_sdk_test {
     [TestFixture]
     public class HarnessConnectorTest
     {
+        private static readonly ILoggerFactory _loggerFactory = LoggerFactory.Create(builder => { builder.AddConsole(); });
         
         string fakeJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
             ".eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbnZpcm9ubWVudCI6InRlc3QiLCJjbHVzdGVySWRlbnRpZmllciI6InRlc3QiLCJhY2NvdW50SUQiOiJ0ZXN0In0" +
@@ -53,7 +55,7 @@ namespace ff_server_sdk_test {
             var client = new Client(mockHttpClient);
             client.BaseUrl = "http://dummy:1234";
             var mockCallback = new Mock<TestCallback>();
-            var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client);
+            var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client, _loggerFactory);
             await connector.Authenticate();
   
             //Act
@@ -72,7 +74,7 @@ namespace ff_server_sdk_test {
             var client = new Client(mockHttpClient);
             client.BaseUrl = "http://dummy:1234";
             var mockCallback = new Mock<TestCallback>();
-            var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client);
+            var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client, _loggerFactory);
             await connector.Authenticate();
         
             //Act

--- a/tests/ff-server-sdk-test/api/CfClientTest.cs
+++ b/tests/ff-server-sdk-test/api/CfClientTest.cs
@@ -6,7 +6,6 @@ using io.harness.cfsdk.client.dto;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
-using Serilog;
 using WireMock.Logging;
 using WireMock.Settings;
 using NUnit.Framework;
@@ -28,11 +27,6 @@ namespace ff_server_sdk_test.api
                 Logger = new WireMockConsoleLogger(),
                 ThrowExceptionWhenMatcherFails = true
             });
-
-            Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Verbose()
-                .WriteTo.Console()
-                .CreateLogger();
         }
 
         [TearDown]
@@ -69,7 +63,7 @@ namespace ff_server_sdk_test.api
                     .Identifier("CfClientTest")
                     .build();
 
-            Log.Information("Running at " + server.Url);
+            Console.WriteLine("Running at " + server.Url);
 
             var client = new CfClient("dummy api key", Config.Builder()
                 .debug(true)

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -17,19 +17,22 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using io.harness.cfsdk.HarnessOpenMetricsAPIService;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace ff_server_sdk_test.api.analytics
 {
     [TestFixture]
     public class AnalyticsManagerTests
     {
+        private static readonly ILoggerFactory _loggerFactory = LoggerFactory.Create(builder => { builder.AddConsole(); });
+
         [Test]
         public void Should_add_single_evaluation_for_single_feature_to_analytics_cache()
         {
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock);
+            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, _loggerFactory);
 
             var variation = new Variation();
             var target = new io.harness.cfsdk.client.dto.Target();
@@ -37,7 +40,7 @@ namespace ff_server_sdk_test.api.analytics
             var featureConfig1 = CreateFeatureConfig("feature1");
             var analytics = new Analytics(featureConfig1, target, variation, EventType.METRICS);
 
-            var sut = new MetricsProcessor(new LocalConnector("TEST"), new Config(), null, analyticsCacheMock, analyticsPublisherServiceMock);
+            var sut = new MetricsProcessor(new LocalConnector("TEST"), new Config(), null, analyticsCacheMock, analyticsPublisherServiceMock, _loggerFactory);
 
             // Act
             sut.PushToCache(target, featureConfig1, variation);
@@ -53,7 +56,7 @@ namespace ff_server_sdk_test.api.analytics
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock);
+            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, _loggerFactory);
 
             var target = new io.harness.cfsdk.client.dto.Target();
             var variation = new Variation();
@@ -62,7 +65,7 @@ namespace ff_server_sdk_test.api.analytics
             var featureConfig = CreateFeatureConfig("feature1");
             var analytics = new Analytics(featureConfig, target, variation, EventType.METRICS);
 
-            var sut = new MetricsProcessor(new LocalConnector("TEST"), new Config(), null, analyticsCacheMock, analyticsPublisherServiceMock);
+            var sut = new MetricsProcessor(new LocalConnector("TEST"), new Config(), null, analyticsCacheMock, analyticsPublisherServiceMock, _loggerFactory);
 
             // Act
             sut.PushToCache(target, featureConfig, variation);
@@ -83,7 +86,7 @@ namespace ff_server_sdk_test.api.analytics
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock);
+            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, _loggerFactory);
 
             var target = new io.harness.cfsdk.client.dto.Target();
             var variation = new Variation();
@@ -95,7 +98,7 @@ namespace ff_server_sdk_test.api.analytics
             var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
             var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
 
-            var sut = new MetricsProcessor(new LocalConnector("TEST"), new Config(), null, analyticsCacheMock, analyticsPublisherServiceMock);
+            var sut = new MetricsProcessor(new LocalConnector("TEST"), new Config(), null, analyticsCacheMock, analyticsPublisherServiceMock, _loggerFactory);
 
             // Act
             sut.PushToCache(target, featureConfig1, variation);
@@ -114,7 +117,7 @@ namespace ff_server_sdk_test.api.analytics
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock);
+            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, _loggerFactory);
 
             var target = new io.harness.cfsdk.client.dto.Target();
             var variation = new Variation();
@@ -126,7 +129,7 @@ namespace ff_server_sdk_test.api.analytics
             var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
             var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
 
-            var sut = new MetricsProcessor(new LocalConnector("TEST"), new Config(), null, analyticsCacheMock, analyticsPublisherServiceMock);
+            var sut = new MetricsProcessor(new LocalConnector("TEST"), new Config(), null, analyticsCacheMock, analyticsPublisherServiceMock, _loggerFactory);
 
             // Act
             sut.PushToCache(target, featureConfig1, variation);
@@ -151,12 +154,12 @@ namespace ff_server_sdk_test.api.analytics
 
             var bufferSize = 2;
             var configMock = new Config("", "", false, 10, true, 1, bufferSize, 10, 10, 10, false, 10000);
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock);
+            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, _loggerFactory);
 
             var target = new io.harness.cfsdk.client.dto.Target();
             var variation = new Variation();
 
-            var sut = new MetricsProcessor(connectorMock.Object, configMock, null, analyticsCacheMock, analyticsPublisherServiceMock);
+            var sut = new MetricsProcessor(connectorMock.Object, configMock, null, analyticsCacheMock, analyticsPublisherServiceMock, _loggerFactory);
 
             // Act - set cachesize > buffer
             sut.PushToCache(target, CreateFeatureConfig("feature1"), variation);

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -1,22 +1,13 @@
-﻿using Disruptor;
-using Disruptor.Dsl;
-using io.harness.cfsdk.client.cache;
+﻿using io.harness.cfsdk.client.cache;
 using io.harness.cfsdk.client.connector;
 using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.HarnessOpenAPIService;
 using NUnit.Framework;
-using Serilog;
-using System;
-using System.Threading.Tasks;
-using System.Timers;
 using Moq;
 using io.harness.cfsdk.client.api.analytics;
 using io.harness.cfsdk.client.api;
-using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
-using System.Diagnostics;
 using io.harness.cfsdk.HarnessOpenMetricsAPIService;
-using System.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace ff_server_sdk_test.api.analytics

--- a/tests/ff-server-sdk-test/connector/EventSourceTest.cs
+++ b/tests/ff-server-sdk-test/connector/EventSourceTest.cs
@@ -51,7 +51,7 @@ namespace ff_server_sdk_test.connector
 
             public void Update(Message message, bool manual)
             {
-                _logger.LogInformation($"Test got stream update, domain={message.Domain} id={message.Identifier} event={message.Event} ver={message.Version} ");
+                _logger.LogInformation("Test got stream update, domain={domain} id={identifier} event={event} ver={version} ", message.Domain, message.Identifier, message.Event, message.Version);
                 Events.Add(message);
                 UpdateCount++;
             }

--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -20,8 +20,6 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="WireMock.Net" Version="1.5.35" />
   </ItemGroup>
 


### PR DESCRIPTION
FFM-9392 - Support Microsoft.Extensions.Logging

What
Remove hardcoded Serilog statements and namespace reference and replace them ILogger statements. Also remove string interpolation and use templates instead.

Logging can now be configured externally using any preferred logging framework. For example, using `Serilog.Extensions.Logging` and `Serilog.Sinks.Console` you can pass in a factory directly via `Config.LoggerFactory`:

```
Log.Logger = new LoggerConfiguration()
    .MinimumLevel.Information()
    .WriteTo.Console().CreateLogger();

var loggerFactory = new SerilogLoggerFactory(Log.Logger);

var ffConfig = Config.Builder()
    .LoggerFactory(loggerFactory)
    .Build();
    
var client = new CfClient(API_KEY, ffConfig);
await client.InitializeAndWait();
```
Alternatively you can use dependency injection
```
var serviceCollection = new ServiceCollection();
serviceCollection.AddSingleton<ILoggerFactory>(new SerilogLoggerFactory());       
```
Gives you something like below in the Console
```
[09:41:22 INF] SDKCODE(auth:2000): Authenticated ok
[09:41:22 INF] SDKCODE(stream:5000): SSE stream connected ok
[09:41:22 INF] SDKCODE(init:1000): The SDK has successfully initialized
[09:41:22 INF] SDK version: 1.2.0.0
```

Why
Avoid imposing a logging framework on our customers and allow them to use their own to make it easier for them to integrate with the SDK without conflicts.

Testing
Manual + Testgrid