### PR TITLE
[FFM-7007] - .NET SDK - TLS - support custom CAs

### DIFF
--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using io.harness.cfsdk.client.cache;
 using Microsoft.Extensions.Logging;
 
@@ -71,6 +73,8 @@ namespace io.harness.cfsdk.client.api
         internal long metricsServiceAcceptableDuration = 10000;
 
         public ILoggerFactory LoggerFactory { get; set; }
+
+        public List<X509Certificate2> TlsTrustedCAs { get; set; } = new();
 
         public Config(string configUrl, string eventUrl, bool streamEnabled, int pollIntervalInSeconds, bool analyticsEnabled, int frequency, int bufferSize,  int connectionTimeout, int readTimeout, int writeTimeout, bool debug, long metricsServiceAcceptableDuration)
         {
@@ -189,11 +193,29 @@ namespace io.harness.cfsdk.client.api
             return this;
         }
 
-        /** Set an ILoggerFactory for the SDK. note: cannot be used in conjunction with getInstance() */
+        /**
+         * <summary>
+         * Set an ILoggerFactory for the SDK. note: cannot be used in conjunction with getInstance()
+         * <summary>
+         */
         public ConfigBuilder LoggerFactory(ILoggerFactory loggerFactory)
         {
             this.configtobuild.LoggerFactory = loggerFactory;
             return this;
         }
+
+        /**
+         * <summary>
+         * List of trusted CAs - for when the given config/event URLs are signed with a private CA. You
+         * should include intermediate CAs too to allow the HTTP client to build a full trust chain.
+         * </summary>
+         */
+        public ConfigBuilder TlsTrustedCAs( List<X509Certificate2> certs )
+        {
+            this.configtobuild.TlsTrustedCAs = certs;
+            return this;
+        }
+
+
     }
 }

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -66,7 +66,7 @@ namespace io.harness.cfsdk.client.connector
                 var certHost = serverCertificate.GetNameInfo(X509NameType.DnsFromAlternativeName, false);
                 if (requestHost != certHost)
                 {
-                    logger.LogError("TLS: Hostname validation failed (sdk requested={reqhost} server cert wants={svrhost}) for {url}",
+                    logger.LogError("SDKCODE(init:1005): TLS Hostname validation failed (sdk requested={reqhost} server cert wants={svrhost}) for {url}",
                         requestHost,
                         certHost,
                         request.RequestUri);
@@ -103,7 +103,7 @@ namespace io.harness.cfsdk.client.connector
                 {
                   if (chain.ChainStatus.Any(s => s.Status != X509ChainStatusFlags.NoError))
                   {
-                      logger.LogError("TLS: Certificate did not validate against trusted store (reason={reason}) for {url}",
+                      logger.LogError("SDKCODE(init:1004): TLS Certificate did not validate against trust store (reason={reason}) for {url}",
                           chain.ChainStatus.First(chain => chain.Status != X509ChainStatusFlags.NoError).Status,
                           request.RequestUri);
                   }

--- a/ff-netF48-server-sdk.sln
+++ b/ff-netF48-server-sdk.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ff-server-sdk-example", "te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "getting_started", "examples\getting_started\getting_started.csproj", "{FD7316AF-9326-4D2A-B218-202A18916480}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tls-example", "tests\tls-example\tls-example.csproj", "{DED15A05-FEA2-4540-8D95-989332F9112A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{FD7316AF-9326-4D2A-B218-202A18916480}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD7316AF-9326-4D2A-B218-202A18916480}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD7316AF-9326-4D2A-B218-202A18916480}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DED15A05-FEA2-4540-8D95-989332F9112A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DED15A05-FEA2-4540-8D95-989332F9112A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DED15A05-FEA2-4540-8D95-989332F9112A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DED15A05-FEA2-4540-8D95-989332F9112A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/tls-example/Program.cs
+++ b/tests/tls-example/Program.cs
@@ -1,0 +1,59 @@
+﻿
+using System.Security.Cryptography.X509Certificates;
+using io.harness.cfsdk.client.api;
+using Serilog;
+using Serilog.Extensions.Logging;
+
+namespace io.harness.tls_example
+{
+    class Program
+    {
+        private static string certAuthority1 =
+            "-----BEGIN CERTIFICATE-----\n<<ADD YOUR CA CERTS HERE>>\n-----END CERTIFICATE-----";
+        
+        
+        static async Task Main(string[] args)
+        {
+            var apiKey = Environment.GetEnvironmentVariable("FF_API_KEY");
+            if (apiKey == null) throw new ArgumentNullException("FF_API_KEY","FF_API_KEY env variable is not set");
+            var flagName = Environment.GetEnvironmentVariable("FF_FLAG_NAME");
+            if (flagName == null) flagName = "test";
+            
+            var loggerFactory = new SerilogLoggerFactory(
+                new LoggerConfiguration()
+                    .MinimumLevel.Verbose()
+                    .WriteTo.Console()
+                    .CreateLogger());
+
+            var cert1 = pemToX509Cert(certAuthority1);
+
+            var trustedCerts = new List<X509Certificate2> { cert1 };
+            
+            var config = Config.Builder()
+                .ConfigUrl("https://localhost:8001/api/1.0")
+                .EventUrl("https://ffserver:8000/api/1.0")
+                .TlsTrustedCAs(trustedCerts)
+                .LoggerFactory(loggerFactory).Build();
+            var client = new CfClient(apiKey, config);
+
+            await client.InitializeAndWait();
+
+            while (true)
+            {
+                var resultBool = client.boolVariation(flagName, null, false);
+                Console.WriteLine($"Flag '{flagName}' = " + resultBool);
+                Thread.Sleep(2 * 1000);
+            }
+            
+        }
+
+        static X509Certificate2 pemToX509Cert(string pem)
+        {
+            pem = pem
+                .Replace("-----BEGIN CERTIFICATE-----",null)
+                .Replace("-----END CERTIFICATE-----",null);
+
+            return new X509Certificate2(Convert.FromBase64String(pem));
+        }
+    }
+}

--- a/tests/tls-example/Program.cs
+++ b/tests/tls-example/Program.cs
@@ -30,7 +30,7 @@ namespace io.harness.tls_example
             var trustedCerts = new List<X509Certificate2> { cert1 };
             
             var config = Config.Builder()
-                .ConfigUrl("https://localhost:8001/api/1.0")
+                .ConfigUrl("https://ffserver:8001/api/1.0")
                 .EventUrl("https://ffserver:8000/api/1.0")
                 .TlsTrustedCAs(trustedCerts)
                 .LoggerFactory(loggerFactory).Build();

--- a/tests/tls-example/tls-example.csproj
+++ b/tests/tls-example/tls-example.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <RootNamespace>tls_example</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ff-netF48-server-sdk.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
[FFM-7007] - .NET SDK - TLS - support custom CAs

What
Allow the SDK user to provide a custom TLS CA via the new config `TlsTrustedCAs` API. This property takes a list of Certificate Authorities in X.509 format via .NET's [X509Certificate2](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2?view=net-7.0) class. You should provide the CA that will be used to validate the certificate sent by the server along with all its intermediate CAs right up until the root.
Prebundle and system provided CAs are switched off to allow servers to be ring-fenced. All CAs need to be provided.

Why
We currently rely on pre-installed CA bundles in the system for TLS connections, e.g. those host names signed by public CAs, it's useful to provide alternative methods of loading private TLS CAs for internal on-prem deployments

Testing
Manual - tested against a ff-server proxy with TLS termination enabled

[FFM-7007]: https://harness.atlassian.net/browse/FFM-7007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ