### PR TITLE
[FFM-9472] - Update wiremock to latest version 1.5.35

### DIFF
--- a/tests/ff-server-sdk-test/api/CfClientTest.cs
+++ b/tests/ff-server-sdk-test/api/CfClientTest.cs
@@ -24,8 +24,7 @@ namespace ff_server_sdk_test.api
         {
             server = WireMockServer.Start(new WireMockServerSettings
             {
-                Logger = new WireMockConsoleLogger(),
-                ThrowExceptionWhenMatcherFails = true
+                Logger = new WireMockConsoleLogger()
             });
         }
 

--- a/tests/ff-server-sdk-test/connector/EventSourceTest.cs
+++ b/tests/ff-server-sdk-test/connector/EventSourceTest.cs
@@ -28,8 +28,7 @@ namespace ff_server_sdk_test.connector
 
             server = WireMockServer.Start(new WireMockServerSettings
             {
-                Logger = new WireMockConsoleLogger(),
-                ThrowExceptionWhenMatcherFails = true
+                Logger = new WireMockConsoleLogger()
             });
         }
 

--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="WireMock.Net" Version="1.5.35" />
+    <PackageReference Include="WireMock.Net" Version="1.5.36" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[FFM-9472] - Update wiremock to latest version 1.5.35

What
Update to the latest version

Why
Get latest security updates

Testing
Manual

[FFM-9472]: https://harness.atlassian.net/browse/FFM-9472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ