### PR TITLE
[FFM-9474] - Update NuGet.Frameworks to version 6.5.1

### DIFF
--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="NuGet.Frameworks" Version="6.5.1" /> <!-- Fixes CVE 2023-29337 -->
     <PackageReference Include="WireMock.Net" Version="1.5.35" />
   </ItemGroup>
 


### PR DESCRIPTION
[FFM-9474] - Update NuGet.Frameworks to version 6.5.1

What
Update NuGet.Frameworks to version 6.5.1 so that a transitive dependency in Microsoft.NET.Test.Sdk is also updated

Why
Removes CVE 2023-29337

Testing
Manual + test grid

[FFM-9474]: https://harness.atlassian.net/browse/FFM-9474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ