### PR TITLE
[FFM-9475] - Update TestCentric.Metadata to version 2.0.0

### DIFF
--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="TestCentric.Metadata" Version="2.0.0" /> <!-- Fixes CVE-2023-4914 -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NuGet.Frameworks" Version="6.5.1" /> <!-- Fixes CVE 2023-29337 -->
     <PackageReference Include="WireMock.Net" Version="1.5.36" />


### PR DESCRIPTION
[FFM-9475] - Update TestCentric.Metadata to version 2.0.0

What
Update TestCentric.Metadata to latest version 2.0.0

Why
Attempt to fix CVE-2023-4914

Testing
Manual + testgrid

[FFM-9475]: https://harness.atlassian.net/browse/FFM-9475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ