### PR TITLE
FFM-9206 - Various cleanups to README and examples 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ For a sample FF .NET SDK project, see our [test .NET project](examples/getting_s
 ![FeatureFlags](https://github.com/harness/ff-python-server-sdk/raw/main/docs/images/ff-gui.png)
 
 ## Requirements
-[.NET Framework >= 4.8](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48)<br>
-or<br>
 [.Net 5.0.104](https://docs.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-using-the-dotnet-cli) or newer (dotnet --version)<br>
 The library is packaged as multi-target supporting `net5.0`, `net6.0` and `net7.0`.
 
@@ -61,8 +59,15 @@ namespace getting_started
 
         static void Main(string[] args)
         {
+            // Configure your logger
+            var loggerFactory = new SerilogLoggerFactory(
+                new LoggerConfiguration()
+                    .MinimumLevel.Information()
+                    .WriteTo.Console()
+                    .CreateLogger());
+
             // Create a feature flag client
-            CfClient.Instance.Initialize(apiKey, Config.Builder().Build());
+            CfClient.Instance.Initialize(apiKey, Config.Builder().LoggerFactory(loggerFactory).Build());
 
             // Create a target (different targets can get different results based on rules)
             Target target = Target.builder()
@@ -96,7 +101,7 @@ If you dont have the right version of dotnet installed locally, or dont want to 
 use docker to quicky get started
 
 ```bash
-docker run -v $(pwd):/app -w /app -e FF_API_KEY=$FF_API_KEY mcr.microsoft.com/dotnet/sdk:5.0 dotnet run --project examples/getting_started/
+docker run -v $(pwd):/app -w /app -e FF_API_KEY=$FF_API_KEY mcr.microsoft.com/dotnet/sdk:6.0 dotnet run --framework net6.0 --project examples/getting_started/
 ```
 
 ### Additional Reading

--- a/examples/getting_started/Program.cs
+++ b/examples/getting_started/Program.cs
@@ -22,7 +22,7 @@ namespace getting_started
                     .CreateLogger());
 
             // Create a feature flag client
-            var client = new CfClient(apiKey, Config.Builder()/*.LoggerFactory(loggerFactory)*/.Build());
+            var client = new CfClient(apiKey, Config.Builder().LoggerFactory(loggerFactory).Build());
             client.InitializeAndWait().Wait();
 
             // Create a target (different targets can get different results based on rules)

--- a/examples/getting_started/getting_started.csproj
+++ b/examples/getting_started/getting_started.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RestoreSources>$(RestoreSources);https://api.nuget.org/v3/index.json</RestoreSources>
 
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ff-dotnet-server-sdk" Version="1.*.*" />
+    <PackageReference Include="ff-dotnet-server-sdk" Version="1.2.*" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>


### PR DESCRIPTION
FFM-9206 - Various cleanups to README and examples 

What
Update examples to fresh new loggers + update example in README to add --framework option. Also set getting started to use 1.2.*

Testing
Confirmed getting started is working ok:

docker run -v $(pwd):/app -w /app -e FF_API_KEY=$FF_API_KEY mcr.microsoft.com/dotnet/sdk:6.0 dotnet run --framework net6.0 --project examples/getting_started/

[10:20:10 INF] SDKCODE(auth:2000): Authenticated ok [10:20:10 INF] SDKCODE(metric:7000): Metrics thread started [10:20:10 INF] SDKCODE(stream:5000): SSE stream connected ok [10:20:10 INF] SDKCODE(init:1000): The SDK has successfully initialized [10:20:10 INF] SDK version: 1.2.1.0
Flag 'harnessappdemodarkmode' = True
Flag 'harnessappdemodarkmode' = True
Flag 'harnessappdemodarkmode' = True
Flag 'harnessappdemodarkmode' = True
[10:20:44 INF] SDKCODE(stream:5002): SSE event received data: {"environment":"xxxxxxxxxx","domain":"flag","identifier":"str","version":3,"event":"patch"}

Flag 'harnessappdemodarkmode' = True
Flag 'harnessappdemodarkmode' = True
Flag 'harnessappdemodarkmode' = True
Flag 'harnessappdemodarkmode' = True
Flag 'harnessappdemodarkmode' = True
Flag 'harnessappdemodarkmode' = True