### PR TITLE
[FFM-9659] - Fix targets not updating correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 bin
 obj
 .vscode
+*.user
+*.bak
+.idea

--- a/Connected Services/HarnessOpenMetricsAPIService/HarnessOpenMetricsAPI.cs
+++ b/Connected Services/HarnessOpenMetricsAPIService/HarnessOpenMetricsAPI.cs
@@ -60,11 +60,12 @@ namespace io.harness.cfsdk.HarnessOpenMetricsAPIService
         /// Send metrics to Analytics server
         /// </remarks>
         /// <param name="environmentUUID">environment parameter in query.</param>
+        /// <param name="cluster">Unique identifier for the cluster for the account</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task MetricsAsync(string environmentUUID, Metrics body)
+        public virtual System.Threading.Tasks.Task MetricsAsync(string environmentUUID, string cluster, Metrics body)
         {
-            return MetricsAsync(environmentUUID, body, System.Threading.CancellationToken.None);
+            return MetricsAsync(environmentUUID, cluster, body, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -75,16 +76,22 @@ namespace io.harness.cfsdk.HarnessOpenMetricsAPIService
         /// Send metrics to Analytics server
         /// </remarks>
         /// <param name="environmentUUID">environment parameter in query.</param>
+        /// <param name="cluster">Unique identifier for the cluster for the account</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task MetricsAsync(string environmentUUID, Metrics body, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task MetricsAsync(string environmentUUID, string cluster, Metrics body, System.Threading.CancellationToken cancellationToken)
         {
             if (environmentUUID == null)
                 throw new System.ArgumentNullException("environmentUUID");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/metrics/{environmentUUID}");
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/metrics/{environmentUUID}?");
             urlBuilder_.Replace("{environmentUUID}", System.Uri.EscapeDataString(ConvertToString(environmentUUID, System.Globalization.CultureInfo.InvariantCulture)));
+            if (cluster != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("cluster") + "=").Append(System.Uri.EscapeDataString(ConvertToString(cluster, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            urlBuilder_.Length--;
 
             var client_ = _httpClient;
             var disposeClient_ = false;

--- a/Connected Services/HarnessOpenMetricsAPIService/HarnessOpenMetricsAPI.nswag.json
+++ b/Connected Services/HarnessOpenMetricsAPIService/HarnessOpenMetricsAPI.nswag.json
@@ -28,6 +28,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/environmentPathParam/schema"
+          },
+          {
+            "$ref": "#/components/parameters/clusterQueryOptionalParam/schema"
           }
         ],
         "requestBody": {
@@ -213,6 +216,14 @@
       }
     },
     "parameters": {
+      "clusterQueryOptionalParam": {
+        "name": "cluster",
+        "in": "query",
+        "description": "Unique identifier for the cluster for the account",
+        "schema": {
+          "type": "string"
+        }
+      },
       "environmentPathParam": {
         "name": "environmentUUID",
         "in": "path",

--- a/Connected Services/HarnessOpenMetricsAPIService/metrics-v1.yaml
+++ b/Connected Services/HarnessOpenMetricsAPIService/metrics-v1.yaml
@@ -19,6 +19,7 @@ paths:
       operationId: postMetrics
       parameters:
         - $ref: '#/components/parameters/environmentPathParam'
+        - $ref: '#/components/parameters/clusterQueryOptionalParam'
       requestBody:
         content:
           application/json:
@@ -125,6 +126,13 @@ components:
       scheme: bearer
       bearerFormat: JWT
   parameters:
+    clusterQueryOptionalParam:
+      name: cluster
+      in: query
+      required: false
+      description: Unique identifier for the cluster for the account
+      schema:
+        type: string
     environmentPathParam:
       name: environmentUUID
       in: path

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -16,6 +16,7 @@ using io.harness.cfsdk.HarnessOpenAPIService;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using System.Security.Cryptography;
+using Newtonsoft.Json;
 
 namespace io.harness.cfsdk.client.connector
 {
@@ -258,7 +259,7 @@ namespace io.harness.cfsdk.client.connector
                     BaseUrl = config.EventUrl
                 };
                 try {
-                    await client.MetricsAsync(_environment, metrics, cancelToken.Token);
+                    await client.MetricsAsync(_environment, cluster, metrics, cancelToken.Token);
                 }
                 catch (Exception ex) {
                     logger.LogWarning(ex, "SDKCODE(metric:7002): Posting metrics failed, reason: {reason}", ex.Message);

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.2.1</Version>
+        <Version>1.2.2</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.2.1</PackageVersion>
-        <AssemblyVersion>1.2.1</AssemblyVersion>
+        <PackageVersion>1.2.2</PackageVersion>
+        <AssemblyVersion>1.2.2</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2023</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>

--- a/ff-netF48-server-sdk.csproj.user
+++ b/ff-netF48-server-sdk.csproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ShowAllFiles>false</ShowAllFiles>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
[FFM-9659] - Fix targets not updating correctly

What
Fix API definition for metrics which were missing the cluster identifier. Readd this back on when posting metrics. Also some additional fixes to remove meta data we don't need added by the JSON lib.

Why
Reports of targets not appearing correctly on UI

Testing
Manual

[FFM-9659]: https://harness.atlassian.net/browse/FFM-9659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ