### PR TITLE
[FFM-9725] - Fix hostname validation on custom TLS certs

### DIFF
--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -65,7 +65,16 @@ namespace io.harness.cfsdk.client.connector
 
                 var requestHost = request.RequestUri?.Host;
                 var certHost = serverCertificate.GetNameInfo(X509NameType.DnsFromAlternativeName, false);
-                if (requestHost != certHost)
+
+                if (requestHost == null || certHost == null)
+                {
+                    logger.LogError("Missing hostname/certhost");
+                    return false;
+                }
+
+                var match = IPAddress.TryParse(certHost, out _) ? requestHost.Equals(certHost) : requestHost.EndsWith(certHost);
+
+                if (!match)
                 {
                     logger.LogError("SDKCODE(init:1005): TLS Hostname validation failed (sdk requested={reqhost} server cert wants={svrhost}) for {url}",
                         requestHost,


### PR DESCRIPTION
[FFM-9725] - Fix hostname validation on custom TLS certs

What
Fix hostname matching to allow sub-domains to be accepted. Use EndsWith() for domains and Equals() for IPs. Note wildcard domains not supported.

Why
Code currently throws an exception on startup if cert is signed against e.g. ff.mydomain.com but SDK requests config.ff.mydomain.com

Testing
Manual

[FFM-9725]: https://harness.atlassian.net/browse/FFM-9725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ