### PR TITLE
[FFM-9750] - Mark private attributes for deprecation

### DIFF
--- a/client/dto/Target.cs
+++ b/client/dto/Target.cs
@@ -21,7 +21,7 @@ namespace io.harness.cfsdk.client.dto
             attributes = new Dictionary<string, string>();
         }
 
-        [Obsolete("privateAttributes will be removed in a future release use other constructor instead")]
+        [Obsolete("isPrivate and privateAttributes will be removed in a future release use other constructor instead")]
         public Target(string identifier, string name, Dictionary<string, string> attributes, bool isPrivate, HashSet<string> privateAttributes)
         {
             if (attributes == null)
@@ -58,8 +58,11 @@ namespace io.harness.cfsdk.client.dto
         public string Name { get => name; set => name = value; }
         public string Identifier { get => identifier; set => identifier = value; }
         public Dictionary<string, string> Attributes { get => attributes; set => attributes = value; }
+
+        [Obsolete("Private attributes will be removed in a future release")]
         public bool IsPrivate { get => isPrivate; set => isPrivate = value; }
-        [Obsolete("Private attributes not supportted and will be removed in a future release")]
+
+        [Obsolete("Private attributes will be removed in a future release")]
         public HashSet<string> PrivateAttributes { get => privateAttributes; set => privateAttributes = value; }
 
         public override string ToString()

--- a/client/dto/Target.cs
+++ b/client/dto/Target.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace io.harness.cfsdk.client.dto
 {
@@ -20,6 +21,7 @@ namespace io.harness.cfsdk.client.dto
             attributes = new Dictionary<string, string>();
         }
 
+        [Obsolete("privateAttributes will be removed in a future release use other constructor instead")]
         public Target(string identifier, string name, Dictionary<string, string> attributes, bool isPrivate, HashSet<string> privateAttributes)
         {
             if (attributes == null)
@@ -37,10 +39,27 @@ namespace io.harness.cfsdk.client.dto
             PrivateAttributes = privateAttributes;
         }
 
+        public Target(string identifier, string name, Dictionary<string, string> attributes, bool isPrivate)
+        {
+            if (attributes == null)
+            {
+                Attributes = new Dictionary<string, string>();
+            }
+            else
+            {
+                Attributes = attributes;
+            }
+
+            Identifier = identifier;
+            Name = name;
+            IsPrivate = isPrivate;
+        }
+
         public string Name { get => name; set => name = value; }
         public string Identifier { get => identifier; set => identifier = value; }
         public Dictionary<string, string> Attributes { get => attributes; set => attributes = value; }
         public bool IsPrivate { get => isPrivate; set => isPrivate = value; }
+        [Obsolete("Private attributes not supportted and will be removed in a future release")]
         public HashSet<string> PrivateAttributes { get => privateAttributes; set => privateAttributes = value; }
 
         public override string ToString()
@@ -82,11 +101,15 @@ namespace io.harness.cfsdk.client.dto
             this.attributes = attributes;
             return this;
         }
+
+        [Obsolete("Private attributes will be removed in a future release")]
         public TargetBuilder IsPrivate(bool isPrivate)
         {
             this.isPrivate = isPrivate;
             return this;
         }
+
+        [Obsolete("Private attributes will be removed in a future release")]
         public TargetBuilder PrivateAttributes(HashSet<string> privateAttributes)
         {
             this.privateAttributes = privateAttributes;

--- a/client/dto/Target.cs
+++ b/client/dto/Target.cs
@@ -39,7 +39,7 @@ namespace io.harness.cfsdk.client.dto
             PrivateAttributes = privateAttributes;
         }
 
-        public Target(string identifier, string name, Dictionary<string, string> attributes, bool isPrivate)
+        public Target(string identifier, string name, Dictionary<string, string> attributes)
         {
             if (attributes == null)
             {
@@ -52,7 +52,7 @@ namespace io.harness.cfsdk.client.dto
 
             Identifier = identifier;
             Name = name;
-            IsPrivate = isPrivate;
+            IsPrivate = false;
         }
 
         public string Name { get => name; set => name = value; }


### PR DESCRIPTION
[FFM-9750] - Mark private attributes for deprecation

What
We don't support private attributes and the original implementations were never fully completed. Mark them for removal.

[FFM-9750]: https://harness.atlassian.net/browse/FFM-9750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ