### PR TITLE
[FFM-9926] - Testgrid - % rollout - .NET SDK - Fix MM3 hash

### DIFF
--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -27,6 +27,7 @@ namespace io.harness.cfsdk.client.api
     internal class Evaluator : IEvaluator
     {
         private readonly ILogger<Evaluator> logger;
+        private readonly ILoggerFactory loggerFactory;
         private readonly IRepository repository;
         private readonly IEvaluatorCallback callback;
 
@@ -35,6 +36,7 @@ namespace io.harness.cfsdk.client.api
             this.repository = repository;
             this.callback = callback;
             this.logger = loggerFactory.CreateLogger<Evaluator>();
+            this.loggerFactory = loggerFactory;
         }
         private Variation EvaluateVariation(string key, dto.Target target, FeatureConfigKind kind)
         {
@@ -233,7 +235,7 @@ namespace io.harness.cfsdk.client.api
                 {
                     if(servingRule.Serve.Distribution != null)
                     {
-                        DistributionProcessor distributionProcessor = new DistributionProcessor(servingRule.Serve);
+                        DistributionProcessor distributionProcessor = new DistributionProcessor(servingRule.Serve, loggerFactory);
                         return distributionProcessor.loadKeyName(target);
                     }
                     if( servingRule.Serve.Variation != null)
@@ -254,7 +256,7 @@ namespace io.harness.cfsdk.client.api
                 return null;
             }
 
-            DistributionProcessor distributionProcessor = new DistributionProcessor(featureConfig.DefaultServe);
+            DistributionProcessor distributionProcessor = new DistributionProcessor(featureConfig.DefaultServe, loggerFactory);
             return distributionProcessor.loadKeyName(target);
         }
         private bool IsTargetIncludedOrExcludedInSegment(List<string> segmentList, dto.Target target)
@@ -349,7 +351,7 @@ namespace io.harness.cfsdk.client.api
             }
         }
 
-        public static object GetAttrValue(dto.Target target, string attribute)
+        public static string GetAttrValue(dto.Target target, string attribute)
         {
             switch (attribute)
             {

--- a/client/api/rules/Strategy.cs
+++ b/client/api/rules/Strategy.cs
@@ -2,18 +2,21 @@
 using System;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace io.harness.cfsdk.client.api.rules
 {
     public class Strategy
     {
+        private readonly ILogger<Strategy> logger;
         private readonly string value;
         private readonly string bucketBy;
 
-        public Strategy(String value, String bucketBy)
+        public Strategy(String value, String bucketBy, ILoggerFactory loggerFactory)
         {
             this.value = value;
             this.bucketBy = bucketBy;
+            this.logger = loggerFactory.CreateLogger<Strategy>();
         }
 
         public int loadNormalizedNumber()
@@ -24,6 +27,10 @@ namespace io.harness.cfsdk.client.api.rules
         public int loadNormalizedNumberWithNormalizer(int normalizer)
         {
             byte[] valueBytes = Encoding.ASCII.GetBytes(bucketBy + ":" + value);
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("MM3 input [{input}]", Encoding.UTF8.GetString(valueBytes));
+            }
             HashAlgorithm hasher = MurmurHash.Create32(seed: 0);
             var hashcode = (uint)BitConverter.ToInt32(hasher.ComputeHash(valueBytes), 0);
             return (int)(hashcode % normalizer) + 1;

--- a/client/api/rules/Strategy.cs
+++ b/client/api/rules/Strategy.cs
@@ -7,27 +7,25 @@ namespace io.harness.cfsdk.client.api.rules
 {
     public class Strategy
     {
-        public static readonly int ONE_HUNDRED = 100;
-
-        private readonly string identifier;
+        private readonly string value;
         private readonly string bucketBy;
 
-        public Strategy(String identifier, String bucketBy)
+        public Strategy(String value, String bucketBy)
         {
-            this.identifier = identifier;
+            this.value = value;
             this.bucketBy = bucketBy;
         }
 
         public int loadNormalizedNumber()
         {
-            return loadNormalizedNumberWithNormalizer(ONE_HUNDRED);
+            return loadNormalizedNumberWithNormalizer(100);
         }
 
         public int loadNormalizedNumberWithNormalizer(int normalizer)
         {
-            byte[] value = Encoding.ASCII.GetBytes(bucketBy + ":" + identifier);
-            HashAlgorithm hasher = MurmurHash.Create32(seed: 4294967295);
-            long hashcode = hasher.ComputeHash(value).GetHashCode();
+            byte[] valueBytes = Encoding.ASCII.GetBytes(bucketBy + ":" + value);
+            HashAlgorithm hasher = MurmurHash.Create32(seed: 0);
+            var hashcode = (uint)BitConverter.ToInt32(hasher.ComputeHash(valueBytes), 0);
             return (int)(hashcode % normalizer) + 1;
         }
     }

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.2.2</Version>
+        <Version>1.3.0</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.2.2</PackageVersion>
-        <AssemblyVersion>1.2.2</AssemblyVersion>
+        <PackageVersion>1.3.0</PackageVersion>
+        <AssemblyVersion>1.3.0</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2023</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>

--- a/tests/ff-server-sdk-test/api/rules/StrategyTest.cs
+++ b/tests/ff-server-sdk-test/api/rules/StrategyTest.cs
@@ -1,4 +1,5 @@
 using io.harness.cfsdk.client.api.rules;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 namespace ff_server_sdk_test
@@ -8,7 +9,7 @@ namespace ff_server_sdk_test
         [Test]
         public void CheckBucket57IsMatchingCorrectly()
         {
-            Strategy strategy = new Strategy("test", "identifier");
+            Strategy strategy = new Strategy("test", "identifier", new NullLoggerFactory());
             Assert.AreEqual(57, strategy.loadNormalizedNumber());
         }
     }

--- a/tests/ff-server-sdk-test/api/rules/StrategyTest.cs
+++ b/tests/ff-server-sdk-test/api/rules/StrategyTest.cs
@@ -1,0 +1,15 @@
+using io.harness.cfsdk.client.api.rules;
+using NUnit.Framework;
+
+namespace ff_server_sdk_test
+{
+    public class StrategyTest
+    {
+        [Test]
+        public void CheckBucket57IsMatchingCorrectly()
+        {
+            Strategy strategy = new Strategy("test", "identifier");
+            Assert.AreEqual(57, strategy.loadNormalizedNumber());
+        }
+    }
+}


### PR DESCRIPTION
[FFM-9926] - Testgrid - % rollout - .NET SDK - Fix MM3 hash

**What**
Various fixes to MM3 hash to bring it in alignment with GoLang SDK
- Set MM3 seed to 0
- Fixed a problem with hash where GetHashCode() was used instead of BitConverter()
- If bucket_by attribute is missing, fall back to identifier + log new SDK code
- Additional debug statements for easier diagnostics
- Update unit tests

**Why**
Review SDKs to make sure Murmur3 hash calculations are consistent across SDKs and buckets mappings align for customers that rely on this feature.

**Testing**
New percentage rollout tests added to testgrid, these will be committed later

[FFM-9926]: https://harness.atlassian.net/browse/FFM-9926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ