### PR TITLE
[FFM-9946] - Add netstandard2.0 support

### DIFF
--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -55,7 +55,7 @@ namespace io.harness.cfsdk.client.connector
                 return new HttpClient();
             }
 
-#if NETSTANDARD
+#if (NETSTANDARD || NET461)
             throw new NotSupportedException("Custom TLS certificates require .net5.0 target or greater");
 #else
             var logger = loggerFactory.CreateLogger<HarnessConnector>();

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -55,6 +55,9 @@ namespace io.harness.cfsdk.client.connector
                 return new HttpClient();
             }
 
+#if NETSTANDARD
+            throw new NotSupportedException("Custom TLS certificates require .net5.0 target or greater");
+#else
             var logger = loggerFactory.CreateLogger<HarnessConnector>();
             var handler = new HttpClientHandler();
 
@@ -127,6 +130,8 @@ namespace io.harness.cfsdk.client.connector
             };
 
             return new HttpClient(handler, true);
+
+#endif // NETSTANDARD
         }
 
         private static HttpClient ApiHttpClient(Config config, ILoggerFactory loggerFactory)

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <!-- The SDK must be built with .NET 7 however we must also keep compatibility with .NET 5/6 hence SupportedOSPlatformVersion=9 below -->
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net461;net5.0;net6.0;net7.0</TargetFrameworks>
         <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
         <LangVersion>9.0</LangVersion>
         <PackageId>ff-dotnet-server-sdk</PackageId>

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <!-- The SDK must be built with .NET 7 however we must also keep compatibility with .NET 5/6 hence SupportedOSPlatformVersion=9 below -->
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net461;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net461;net5.0;net6.0;net7.0</TargetFrameworks>
         <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
         <LangVersion>9.0</LangVersion>
         <PackageId>ff-dotnet-server-sdk</PackageId>

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <!-- The SDK must be built with .NET 7 however we must also keep compatibility with .NET 5/6 hence SupportedOSPlatformVersion=9 below -->
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
         <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
         <LangVersion>9.0</LangVersion>
         <PackageId>ff-dotnet-server-sdk</PackageId>


### PR DESCRIPTION
[FFM-9946] - Add `netstandard2.0`/`net461` targets

**What**
Adds the following targets to the SDK. `netstandard2.0` and `net461`
Note if using the SDK on a target older than .NET5 then the following config method will throw a 'not supported' exception: `Config.Builder().TlsTrustedCAs()` since the required APIs are not available on these older platforms.

**Why**
This allows us to increase our user-base to older .NET versions while disabling newer features these users may not require.

**Testing**
Manual + testgrid


[FFM-9946]: https://harness.atlassian.net/browse/FFM-9946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ