### PR TITLE
 [FFM-9951] - Remove "Collection was modified" exception

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,3 @@
-
 echo ".NET version installed:"
 dotnet --version
 

--- a/client/api/CfClientException.cs
+++ b/client/api/CfClientException.cs
@@ -8,5 +8,9 @@ namespace io.harness.cfsdk.client.api
         {
           
         }
+
+        public CfClientException(string  errorMessage, Exception innerException) : base(errorMessage, innerException)
+        {
+        }
     }
 }

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -107,7 +107,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch (CfClientException ex)
             {
-                logger.LogError(ex,"Exception was raised when fetching flags data with the message {reason}", ex.Message);
+                logger.LogError(ex,"Exception was raised when fetching flags data with the message: {reason}", ex.Message);
                 throw;
             }
         }
@@ -126,7 +126,7 @@ namespace io.harness.cfsdk.client.api
             }
             catch (CfClientException ex)
             {
-                logger.LogError(ex, "Exception was raised when fetching segments data with the message {reason}", ex.Message);
+                logger.LogError(ex, "Exception was raised when fetching segments data with the message: {reason}", ex.Message);
                 throw;
             }
         }

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Threading;
 using io.harness.cfsdk.client.connector;
@@ -97,7 +98,8 @@ namespace io.harness.cfsdk.client.api
                 logger.LogDebug("Fetching flags started");
                 var flags = await this.connector.GetFlags();
                 logger.LogDebug("Fetching flags finished");
-                foreach (var item in flags)
+ 
+                foreach (var item in flags.ToArray())
                 {
                     repository.SetFlag(item.Feature, item);
                 }
@@ -116,7 +118,8 @@ namespace io.harness.cfsdk.client.api
                 logger.LogDebug("Fetching segments started");
                 IEnumerable<Segment> segments = await connector.GetSegments();
                 logger.LogDebug("Fetching segments finished");
-                foreach (Segment item in segments)
+
+                foreach (Segment item in segments.ToArray())
                 {
                     repository.SetSegment(item.Identifier, item);
                 }

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -232,11 +232,11 @@ namespace io.harness.cfsdk.client.connector
                     logger.LogError("Initiate reauthentication");
                     callback.OnReauthenticateRequested();
                 }
-                throw new CfClientException(ex.Message);
+                throw new CfClientException(ex.Message, ex);
             }
             catch (Exception ex)
             {
-                throw new CfClientException(ex.Message);
+                throw new CfClientException(ex.Message, ex);
             }
         }
         public async Task<IEnumerable<FeatureConfig>> GetFlags()

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -352,8 +352,8 @@ namespace io.harness.cfsdk.client.connector
 
         public void Close()
         {
-            cancelToken.Cancel();
-            currentStream.Close();
+            cancelToken?.Cancel();
+            currentStream?.Close();
         }
 
         private static void PrintCert(ILogger logger, X509Certificate2 cert)

--- a/tests/ff-server-sdk-test/HarnessConnectorTest.cs
+++ b/tests/ff-server-sdk-test/HarnessConnectorTest.cs
@@ -72,7 +72,7 @@ namespace ff_server_sdk_test {
             var mockHttpClient = MockedHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.Forbidden });
             var client = new Client(mockHttpClient);
             var mockCallback = new Mock<TestCallback>();
-            var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client);
+            var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client, new NullLoggerFactory());
             await connector.Authenticate();
 
             //Act

--- a/tests/ff-server-sdk-test/HarnessConnectorTest.cs
+++ b/tests/ff-server-sdk-test/HarnessConnectorTest.cs
@@ -66,6 +66,24 @@ namespace ff_server_sdk_test {
         }
         
         [Test]
+        public async Task ShouldReAuthWhenGetFlagsReturns403()
+        {
+            //Arrange
+            var mockHttpClient = MockedHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.Forbidden });
+            var client = new Client(mockHttpClient);
+            var mockCallback = new Mock<TestCallback>();
+            var connector = new HarnessConnector("test", new Config(), mockCallback.Object, new HttpClient(), new HttpClient(), new HttpClient(), client);
+            await connector.Authenticate();
+
+            //Act
+            var exception = Assert.ThrowsAsync<CfClientException>(async () => await connector.GetFlags());
+
+            //Assert
+            Assert.That(exception!.Message.Contains("The HTTP status code of the response was not expected (403)"));
+            mockCallback.Verify(it => it.OnReauthenticateRequested());
+        }
+
+        [Test]
         public async Task ShouldNotReAuthWhenGetFlagReturns400()
         {
             //Arrange

--- a/tests/ff-server-sdk-test/api/CannedResponses.cs
+++ b/tests/ff-server-sdk-test/api/CannedResponses.cs
@@ -16,8 +16,7 @@ namespace ff_server_sdk_test.api
     {
         public static string MakeEmptyBody()
         {
-            return
-                "[]";
+            return "[]";
         }
 
         public static string MakeFeatureConfigBodyWithVariationToTargetMapSetToNull()

--- a/tests/ff-server-sdk-test/api/CannedResponses.cs
+++ b/tests/ff-server-sdk-test/api/CannedResponses.cs
@@ -14,10 +14,45 @@ namespace ff_server_sdk_test.api
 
     public static class CannedResponses
     {
+        public static string MakeEmptyBody()
+        {
+            return
+                "[]";
+        }
+
         public static string MakeFeatureConfigBodyWithVariationToTargetMapSetToNull()
         {
             return
                 "[{\"variationToTargetMap\":null,\"project\":\"Project\",\"environment\":\"Environment\",\"feature\":\"FeatureWithVariationToTargetMapSetAsNull\",\"state\":\"on\",\"kind\":\"string\",\"variations\":[ { \"identifier\": \"on\", \"name\": \"on\", \"value\": \"on\" } ],\"rules\":[],\"defaultServe\":{  \"variation\":\"on\"  },\"offVariation\":\"off\",\"prerequisites\":[],\"version\":1}]";
+        }
+
+        public static string MakeMultiFeatureConfigBody(int times)
+        {
+            var flags = new List<FeatureConfig>();
+
+            for (int i = 0; i < times; i++)
+            {
+                var flag = new FeatureConfig
+                {
+                    Feature = "Feature"+i,
+                    Environment = "Environment",
+                    Kind = FeatureConfigKind.Boolean,
+                    Prerequisites = new List<Prerequisite>(),
+                    Project = "Project",
+                    Rules = new List<ServingRule>(),
+                    State = FeatureState.On,
+                    Variations = new List<Variation>(),
+                    Version = 1,
+                    AdditionalProperties = new Dictionary<string, object>(),
+                    DefaultServe = new Serve(),
+                    OffVariation = "off"
+                };
+                flags.Add(flag);
+            }
+            
+            var body = JsonConvert.SerializeObject(flags, new JsonSerializerSettings());
+            Console.WriteLine("feature config to return: " + body);
+            return body;
         }
 
         public static string MakeFeatureConfigBody()

--- a/tests/ff-server-sdk-test/api/CfClientTest.cs
+++ b/tests/ff-server-sdk-test/api/CfClientTest.cs
@@ -6,9 +6,10 @@ using io.harness.cfsdk.client.dto;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
-using WireMock.Logging;
 using WireMock.Settings;
 using NUnit.Framework;
+using WireMock.Logging;
+
 
 namespace ff_server_sdk_test.api
 {
@@ -87,6 +88,63 @@ namespace ff_server_sdk_test.api
 
             var result = client.stringVariation("FeatureWithVariationToTargetMapSetAsNull", target, "failed");
             Assert.That(result, Is.EqualTo("on"), "did not get correct flag state");
+        }
+
+        [Ignore("Currently used for manual testing - might be extended into an actual test with assertions later")]
+        [Test]
+        public void ShouldTriggerPollingException()
+        {
+            server
+                .Given(Request.Create().WithPath("/api/1.0/client/auth").UsingPost())
+                .RespondWith(MakeAuthResponse());
+
+            server
+                .Given(Request.Create()
+                    .WithPath("/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs")
+                    .UsingGet())
+                .RespondWith(Response.Create()
+                    .WithStatusCode(999) // Force exception handler in PollingProcessor -> OnTimedEventAsync to trigger
+                    .WithBody(MakeEmptyBody())
+                );
+
+            server
+                .Given(Request.Create()
+                    .WithPath("/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target-segments").UsingGet())
+                .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody(MakeEmptyBody()));
+
+            var target =
+                Target.builder()
+                    .Name("CfClientTest")
+                    .Attributes(new Dictionary<string, string> { { "attr", "val" } })
+                    .Identifier("CfClientTest")
+                    .build();
+
+            Console.WriteLine("Running at " + server.Url);
+
+            var client = new CfClient("dummy api key", Config.Builder()
+                .debug(true)
+                .SetStreamEnabled(false)
+                .SetAnalyticsEnabled(false)
+                .ConfigUrl(server.Url + "/api/1.0")
+                .Build());
+
+            CountdownEvent initLatch = new CountdownEvent(1);
+
+            client.InitializationCompleted += (sender, e) =>
+            {
+                Console.WriteLine("Initialization Completed");
+                initLatch.Signal();
+            };
+
+            var success = client.InitializeAndWait().Wait(10000);
+            Assert.IsTrue(success, "timeout while waiting for InitializeAndWait()");
+
+            var ok = initLatch.Wait(TimeSpan.FromSeconds(30));
+            Assert.That(ok, Is.True, "failed to init in time");
+
+            // todo assert that the 2nd poll came through
         }
     }
 }

--- a/tests/ff-server-sdk-test/api/CfClientTest.cs
+++ b/tests/ff-server-sdk-test/api/CfClientTest.cs
@@ -79,7 +79,8 @@ namespace ff_server_sdk_test.api
                 initLatch.Signal();
             };
 
-            client.InitializeAndWait();
+            var success = client.InitializeAndWait().Wait(10000);
+            Assert.IsTrue(success, "timeout while waiting for InitializeAndWait()");
 
             var ok = initLatch.Wait(TimeSpan.FromMinutes(2));
             Assert.That(ok, Is.True, "failed to init in time");

--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="NuGet.Frameworks" Version="6.5.1" /> <!-- Fixes CVE 2023-29337 -->
     <PackageReference Include="WireMock.Net" Version="1.5.36" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
+    <PackageReference Include="WireMock.Net.FluentAssertions" Version="1.5.35" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 [FFM-9951] - Remove "Collection was modified" exception

 **What**
 Add some hardening, copy list before iterating, log exception details + additional null checks
Polling Processor will now keep trace of inner exceptions for more complete stacktraces.

 **Why**
 We're seeing reports of "Collection was modified; enumeration operation may not execute." in the field when the stream drops.

 **Testing**
 Manual + Unit tests

[FFM-9951]: https://harness.atlassian.net/browse/FFM-9951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ