### PR TITLE
[FFM-10184] - WaitForInitialization updates

### DIFF
--- a/client/api/AuthService.cs
+++ b/client/api/AuthService.cs
@@ -39,7 +39,7 @@ namespace io.harness.cfsdk.client.api
             if (authTimer != null) return;
 
             this.retries = 0;
-            // initiate authentication
+            logger.LogDebug("Initiate authentication");
             authTimer = new Timer(OnTimedEvent, null, 0, config.PollIntervalInMiliSeconds);
         }
         public void Stop()

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -134,9 +134,17 @@ namespace io.harness.cfsdk.client.api
         /// <returns></returns>
         internal bool WaitForSdkToBeReady(int timeoutMs)
         {
-            var result = sdkReadyLatch.Wait(timeoutMs);
-            logger.LogTrace("Got sdkReadyLatch signal, WaitForSdkToBeReady now released");
-            return result;
+            var success = sdkReadyLatch.Wait(timeoutMs);
+            if (success)
+            {
+                logger.LogTrace("Got sdkReadyLatch signal, WaitForSdkToBeReady now released");
+            }
+            else
+            {
+                logger.LogWarning("Did not get a signal on sdkReadyLatch within given timeout");
+            }
+
+            return success;
         }
 
         #endregion

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -125,6 +125,7 @@ namespace io.harness.cfsdk.client.api
             logger.LogTrace("Signal sdkReadyLatch to release");
             sdkReadyLatch.Signal();
             logger.LogInformation("SDKCODE(init:1000): The SDK has successfully initialized");
+            logger.LogInformation("SDK version: " + Assembly.GetExecutingAssembly().GetName().Version);
         }
 
         /// <summary>
@@ -200,7 +201,6 @@ namespace io.harness.cfsdk.client.api
 
         private void OnNotifyInitializationCompleted()
         {
-            logger.LogInformation("SDK version: " + Assembly.GetExecutingAssembly().GetName().Version);
             InitializationCompleted?.Invoke(parent, EventArgs.Empty);
         }
         private void OnNotifyEvaluationChanged(string identifier)

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -29,11 +29,6 @@ namespace io.harness.cfsdk.client.api
         /// Start periodic pooling
         /// </summary>
         void Start();
-        /// <summary>
-        /// async function, returns after initial set of flags and segments are returned 
-        /// </summary>
-        /// <returns>true</returns>
-        Task<bool> ReadyAsync();
     }
 
     /// <summary>
@@ -59,13 +54,7 @@ namespace io.harness.cfsdk.client.api
             this.repository = repository;
             this.connector = connector;
             this.config = config;
-            this.readyEvent = new SemaphoreSlim(0, 3);
             this.logger = loggerFactory.CreateLogger<PollingProcessor>();
-        }
-        public async Task<bool> ReadyAsync()
-        {
-            await readyEvent.WaitAsync();
-            return true;
         }
 
         public void Start()
@@ -78,9 +67,12 @@ namespace io.harness.cfsdk.client.api
                 intervalMs = 60000;
             }
 
+            logger.LogDebug("Populate cache for first time after authentication");
+            Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() });
+
             logger.LogDebug("SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}", intervalMs);
             // start timer which will initiate periodic reading of flags and segments
-            pollTimer = new Timer(OnTimedEventAsync, null, 0, intervalMs);
+            pollTimer = new Timer(OnTimedEventAsync, null, intervalMs, intervalMs);
         }
         public void Stop()
         {

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -68,7 +68,7 @@ namespace io.harness.cfsdk.client.api
             }
 
             logger.LogDebug("Populate cache for first time after authentication");
-            Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() });
+            Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() }).Wait();
 
             logger.LogDebug("SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}", intervalMs);
             // start timer which will initiate periodic reading of flags and segments

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -70,6 +70,7 @@ namespace io.harness.cfsdk.client.connector
         {
             try
             {
+                Debug.Assert(httpClient != null);
 
                 logger.LogDebug("Starting EventSource service.");
                 using (Stream stream = await this.httpClient.GetStreamAsync(url))

--- a/tests/ff-server-sdk-test/InitTest.cs
+++ b/tests/ff-server-sdk-test/InitTest.cs
@@ -7,7 +7,7 @@ using Serilog.Extensions.Logging;
 
 namespace ff_server_sdk_test
 {
-    [Ignore("This test is designed for running manually with an FF_API_KEY env variable")]
+    [Ignore("This test is designed for running manually with an FF_API_KEY env variable + a bool flag named 'test' set to true")]
     public class InitTest
     {
         private string apiKey = Environment.GetEnvironmentVariable("FF_API_KEY");
@@ -41,6 +41,7 @@ namespace ff_server_sdk_test
             {
                 var result = client.boolVariation("test", target, false);
                 Console.WriteLine(testName + " " + i + " got " + result);
+                Assert.IsTrue(result);
             }
         }
 

--- a/tests/ff-server-sdk-test/InitTest.cs
+++ b/tests/ff-server-sdk-test/InitTest.cs
@@ -1,0 +1,108 @@
+using System;
+using io.harness.cfsdk.client.api;
+using io.harness.cfsdk.client.dto;
+using NUnit.Framework;
+using Serilog;
+using Serilog.Extensions.Logging;
+
+namespace ff_server_sdk_test
+{
+    [Ignore("This test is designed for running manually with an FF_API_KEY env variable")]
+    public class InitTest
+    {
+        private string apiKey = Environment.GetEnvironmentVariable("FF_API_KEY");
+        private Config config;
+        private Target target;
+
+        [OneTimeSetUp]
+        public void Init()
+        {
+            apiKey = Environment.GetEnvironmentVariable("FF_API_KEY");
+            if (apiKey == null) throw new ArgumentNullException("FF_API_KEY","FF_API_KEY env variable is not set");
+
+            var loggerFactory = new SerilogLoggerFactory(
+                new LoggerConfiguration()
+                    .MinimumLevel.Verbose()
+                    .WriteTo.Console()
+                    .CreateLogger());
+
+            config = Config.Builder()
+                .LoggerFactory(loggerFactory).Build();
+
+            target = Target.builder()
+                .Name("DotNET SDK init test")
+                .Identifier("dotnetsdkinittest")
+                .build();
+        }
+
+        private void Do10FlagChecks(ICfClient client, string testName)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                var result = client.boolVariation("test", target, false);
+                Console.WriteLine(testName + " " + i + " got " + result);
+            }
+        }
+
+        [Test]
+        public void CfClientInstance_With_WaitForInitialization()
+        {
+            CfClient.Instance.Initialize(apiKey, config);
+            CfClient.Instance.WaitForInitialization();
+            Do10FlagChecks(CfClient.Instance, System.Reflection.MethodBase.GetCurrentMethod()?.Name ?? "unknown");
+            CfClient.Instance.Close();                 // trying to close the singleton is a non-op, versions prior to 1.4.0 would throw exceptions
+        }
+
+        [Test]
+        public void CfClientCtor_With_WaitForInitialization()
+        {
+            var client = new CfClient(apiKey, config);
+            client.WaitForInitialization();
+            Do10FlagChecks(client, System.Reflection.MethodBase.GetCurrentMethod()?.Name ?? "unknown");
+            client.Close();
+            Console.WriteLine("initWith_ConstructorWaitForInit done");
+        }
+
+        [Test]
+        public void CfClientDefaultCtor_With_WaitForInitialization()
+        {
+            // NOTE this constructor pattern will fail since no api key was or can be given, the constructor will be deprecated
+            var client = new CfClient();
+            var result = client.WaitForInitialization(1000);
+            client.Close();
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void CfClientCtor_With_InitAndWait_HappyPath_LegacyWillBeRemoved()
+        {
+            var client = new CfClient(apiKey, config);
+            var result = client.InitializeAndWait().Wait(-1);
+            Assert.IsTrue(result);
+            Do10FlagChecks(client, System.Reflection.MethodBase.GetCurrentMethod()?.Name ?? "unknown");
+            client.Close();
+        }
+
+        [Test]
+        public void CfClientCtor_With_InitAndWait_ShouldThrowIfWrongInstanceUsed_LegacyWillBeRemoved()
+        {
+            var client = new CfClient(apiKey, config);
+
+            // wrong instance is used so SDK will throw assertion error
+            Assert.Throws(Is.TypeOf<AggregateException>(), 
+                () => CfClient.Instance.InitializeAndWait().Wait(5000));
+
+            client.Close();
+        }
+
+        [Test]
+        public void CfClientInstance_With_InitAndWait_LegacyUsage2_WillBeRemoved()
+        {
+            // Check case where CfClient.Instance.Initialize + CfClient.Instance.InitializeAndWait().Wait are used together
+            CfClient.Instance.Initialize(apiKey, config);
+            var result = CfClient.Instance.InitializeAndWait().Wait(5000);
+            Do10FlagChecks(CfClient.Instance, System.Reflection.MethodBase.GetCurrentMethod()?.Name ?? "unknown");
+            Assert.IsTrue(result);
+        }
+    }
+}

--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -24,6 +24,8 @@
     <PackageReference Include="WireMock.Net" Version="1.5.36" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="WireMock.Net.FluentAssertions" Version="1.5.35" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[FFM-10184] - WaitForInitialization updates

**What**
Unify old and new code to make WaitForInitialization() and legacy InitializeAndWait() work on the same latch. Also various updates and fixes with new (manual) unit tests added.

**Why**
Ensure all entrypoints into SDK are tested and find which code need to be deprecated.

**Testing**
Manual + testgrid

[FFM-10184]: https://harness.atlassian.net/browse/FFM-10184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ