### PR TITLE
[FFM-10222] - Config ConnectionTimeout (milliseconds) being treated as seconds internally

### DIFF
--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -138,7 +138,7 @@ namespace io.harness.cfsdk.client.connector
         {
             HttpClient client = CreateHttpClientWithTls(config, loggerFactory);
             client.BaseAddress = new Uri(config.ConfigUrl);
-            client.Timeout = TimeSpan.FromSeconds(config.ConnectionTimeout);
+            client.Timeout = TimeSpan.FromMilliseconds(config.ConnectionTimeout);
             client.DefaultRequestHeaders.Add("Harness-SDK-Info", $".Net {SdkVersion} Server");
             return client;
         }
@@ -146,7 +146,7 @@ namespace io.harness.cfsdk.client.connector
         {
             HttpClient client = CreateHttpClientWithTls(config, loggerFactory);
             client.BaseAddress = new Uri(config.EventUrl);
-            client.Timeout = TimeSpan.FromSeconds(config.ConnectionTimeout);
+            client.Timeout = TimeSpan.FromMilliseconds(config.ConnectionTimeout);
             client.DefaultRequestHeaders.Add("Harness-SDK-Info", $".Net {SdkVersion} Client");
             if (_accountId != null)
             {

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.4.0</Version>
+        <Version>1.4.1</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.4.0</PackageVersion>
-        <AssemblyVersion>1.4.0</AssemblyVersion>
+        <PackageVersion>1.4.1</PackageVersion>
+        <AssemblyVersion>1.4.1</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2023</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>


### PR DESCRIPTION
[FFM-10222] - Config ConnectionTimeout (milliseconds) being treated as seconds internally

**What**
Config.ConnectionTimeout is marked as milliseconds in the public API but treated as seconds by HarnessConnector

**Testing**
Manual

[FFM-10222]: https://harness.atlassian.net/browse/FFM-10222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ