### PR TITLE
FFM-10287 Fix thready safety metrics issue

### DIFF
--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -20,8 +20,8 @@ namespace io.harness.cfsdk.client.api.analytics
         private static readonly string VariationValueAttribute = "featureValue";
         private static readonly string VariationIdentifierAttribute = "variationIdentifier";
         private static readonly string TargetAttribute = "target";
-        internal static readonly ConcurrentDictionary<dto.Target, byte> GlobalTargetSet = new ConcurrentDictionary<dto.Target, byte>();
-        internal static readonly ConcurrentDictionary<dto.Target, byte> StagingTargetSet = new ConcurrentDictionary<dto.Target, byte>();
+        internal static readonly ConcurrentDictionary<dto.Target, byte> SeenTargets = new ConcurrentDictionary<dto.Target, byte>();
+        private static readonly ConcurrentDictionary<dto.Target, byte> StagingSeenTargets = new ConcurrentDictionary<dto.Target, byte>();
         private static readonly string SdkType = "SDK_TYPE";
         private static readonly string AnonymousTarget = "anonymous";
         private static readonly string Server = "server";
@@ -55,11 +55,11 @@ namespace io.harness.cfsdk.client.api.analytics
                         connector.PostMetrics(metrics);
                     }
 
-                    foreach (var uniqueTarget in StagingTargetSet.Keys)
+                    foreach (var uniqueTarget in StagingSeenTargets.Keys)
                     {
-                        GlobalTargetSet.TryAdd(uniqueTarget, 0);
+                        SeenTargets.TryAdd(uniqueTarget, 0);
                     }                    
-                    StagingTargetSet.Clear();
+                    StagingSeenTargets.Clear();
                     logger.LogDebug("Successfully sent analytics data to the server");
                     analyticsCache.resetCache();
                 }
@@ -91,10 +91,10 @@ namespace io.harness.cfsdk.client.api.analytics
 
                 FeatureConfig featureConfig = analytics.FeatureConfig;
                 Variation variation = analytics.Variation;
-                if (target != null && !GlobalTargetSet.ContainsKey(target) && !target.IsPrivate)
+                if (target != null && !SeenTargets.ContainsKey(target) && !target.IsPrivate)
                 {
                     HashSet<string> privateAttributes = analytics.Target.PrivateAttributes;
-                    StagingTargetSet.TryAdd(target, 0);
+                    StagingSeenTargets.TryAdd(target, 0);
                     Dictionary<string, string> attributes = target.Attributes;
                     attributes.ToList().ForEach(el =>
                        {

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -4,6 +4,7 @@ using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.HarnessOpenAPIService;
 using io.harness.cfsdk.HarnessOpenMetricsAPIService;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -19,8 +20,8 @@ namespace io.harness.cfsdk.client.api.analytics
         private static readonly string VariationValueAttribute = "featureValue";
         private static readonly string VariationIdentifierAttribute = "variationIdentifier";
         private static readonly string TargetAttribute = "target";
-        private static readonly HashSet<dto.Target> GlobalTargetSet = new HashSet<dto.Target>();
-        private static readonly HashSet<dto.Target> StagingTargetSet = new HashSet<dto.Target>();
+        private static readonly ConcurrentDictionary<dto.Target, byte> GlobalTargetSet = new ConcurrentDictionary<dto.Target, byte>();
+        private static readonly ConcurrentDictionary<dto.Target, byte> StagingTargetSet = new ConcurrentDictionary<dto.Target, byte>();
         private static readonly string SdkType = "SDK_TYPE";
         private static readonly string AnonymousTarget = "anonymous";
         private static readonly string Server = "server";
@@ -54,8 +55,10 @@ namespace io.harness.cfsdk.client.api.analytics
                         connector.PostMetrics(metrics);
                     }
 
-                    StagingTargetSet.ToList().ForEach(element => GlobalTargetSet.Add(element));
-                    StagingTargetSet.Clear();
+                    foreach (var uniqueTarget in StagingTargetSet.Keys)
+                    {
+                        GlobalTargetSet.TryAdd(uniqueTarget, 0);
+                    }                    StagingTargetSet.Clear();
                     logger.LogDebug("Successfully sent analytics data to the server");
                     analyticsCache.resetCache();
                 }
@@ -87,10 +90,10 @@ namespace io.harness.cfsdk.client.api.analytics
 
                 FeatureConfig featureConfig = analytics.FeatureConfig;
                 Variation variation = analytics.Variation;
-                if (target != null && !GlobalTargetSet.Contains(target) && !target.IsPrivate)
+                if (target != null && !GlobalTargetSet.ContainsKey(target) && !target.IsPrivate)
                 {
                     HashSet<string> privateAttributes = analytics.Target.PrivateAttributes;
-                    StagingTargetSet.Add(target);
+                    StagingTargetSet.TryAdd(target, 0);
                     Dictionary<string, string> attributes = target.Attributes;
                     attributes.ToList().ForEach(el =>
                        {

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -20,6 +20,8 @@ namespace io.harness.cfsdk.client.api.analytics
         private static readonly string VariationValueAttribute = "featureValue";
         private static readonly string VariationIdentifierAttribute = "variationIdentifier";
         private static readonly string TargetAttribute = "target";
+        private static readonly string GlobalTargetIdentifier = "__global__cf_target";
+        private static readonly string GlobalTargetName = "Global Target";
         internal static readonly ConcurrentDictionary<dto.Target, byte> SeenTargets = new ConcurrentDictionary<dto.Target, byte>();
         private static readonly ConcurrentDictionary<dto.Target, byte> StagingSeenTargets = new ConcurrentDictionary<dto.Target, byte>();
         private static readonly string SdkType = "SDK_TYPE";
@@ -121,7 +123,7 @@ namespace io.harness.cfsdk.client.api.analytics
                     }
                     else
                     {
-                        SetMetricsAttributes(metricsData, TargetAttribute, target.Identifier);
+                        SetMetricsAttributes(metricsData, TargetAttribute, GlobalTargetIdentifier);
                     }
                        
                     targetData.Identifier = target.Identifier;

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -20,8 +20,8 @@ namespace io.harness.cfsdk.client.api.analytics
         private static readonly string VariationValueAttribute = "featureValue";
         private static readonly string VariationIdentifierAttribute = "variationIdentifier";
         private static readonly string TargetAttribute = "target";
-        private static readonly ConcurrentDictionary<dto.Target, byte> GlobalTargetSet = new ConcurrentDictionary<dto.Target, byte>();
-        private static readonly ConcurrentDictionary<dto.Target, byte> StagingTargetSet = new ConcurrentDictionary<dto.Target, byte>();
+        internal static readonly ConcurrentDictionary<dto.Target, byte> GlobalTargetSet = new ConcurrentDictionary<dto.Target, byte>();
+        internal static readonly ConcurrentDictionary<dto.Target, byte> StagingTargetSet = new ConcurrentDictionary<dto.Target, byte>();
         private static readonly string SdkType = "SDK_TYPE";
         private static readonly string AnonymousTarget = "anonymous";
         private static readonly string Server = "server";

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -58,7 +58,8 @@ namespace io.harness.cfsdk.client.api.analytics
                     foreach (var uniqueTarget in StagingTargetSet.Keys)
                     {
                         GlobalTargetSet.TryAdd(uniqueTarget, 0);
-                    }                    StagingTargetSet.Clear();
+                    }                    
+                    StagingTargetSet.Clear();
                     logger.LogDebug("Successfully sent analytics data to the server");
                     analyticsCache.resetCache();
                 }

--- a/client/dto/Target.cs
+++ b/client/dto/Target.cs
@@ -74,6 +74,53 @@ namespace io.harness.cfsdk.client.dto
         {
             return !string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(identifier);
         }
+        
+        
+        public override bool Equals(object obj)
+        {
+            if (obj is Target other)
+            {
+                if (Identifier != other.Identifier)
+                {
+                    return false;
+                }
+                return AreDictionariesEqual(attributes, other.attributes);
+            }
+            return false;
+        }
+        
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hash = 17;
+
+                // Hash code for Identifier
+                hash = hash * 31 + (Identifier != null ? Identifier.GetHashCode() : 0);
+
+                // Combine hash codes for each key-value pair in the dictionary
+                foreach (var pair in attributes)
+                {
+                    hash = hash * 31 + (pair.Key != null ? pair.Key.GetHashCode() : 0);
+                    hash = hash * 31 + (pair.Value != null ? pair.Value.GetHashCode() : 0);
+                }
+
+                return hash;
+            }
+        }
+
+        private static bool AreDictionariesEqual(Dictionary<string, string> dict1, Dictionary<string, string> dict2)
+        {
+            if (dict1.Count != dict2.Count) 
+                return false;
+
+            foreach (var pair in dict1)
+            {
+                if (!dict2.TryGetValue(pair.Key, out var value) || value != pair.Value)
+                    return false;
+            }
+            return true;
+        }
     }
 
     public class TargetBuilder

--- a/client/dto/Target.cs
+++ b/client/dto/Target.cs
@@ -80,11 +80,7 @@ namespace io.harness.cfsdk.client.dto
         {
             if (obj is Target other)
             {
-                if (Identifier != other.Identifier)
-                {
-                    return false;
-                }
-                return AreDictionariesEqual(attributes, other.attributes);
+                return Identifier == other.Identifier && AreDictionariesEqual(attributes, other.attributes);
             }
             return false;
         }

--- a/client/dto/Target.cs
+++ b/client/dto/Target.cs
@@ -87,7 +87,8 @@ namespace io.harness.cfsdk.client.dto
         
         public override int GetHashCode()
         {
-            unchecked // Overflow is fine, just wrap
+            // Overflow is fine, just wrap
+            unchecked 
             {
                 int hash = 17;
 

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -203,7 +203,7 @@ namespace ff_server_sdk_test.api.analytics
             var analyticsPublisherService = new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
             var metricsProcessor = new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
 
-            int numberOfThreads = 10;
+            const int numberOfThreads = 10;
             var tasks = new List<Task>();
             var targets = new List<io.harness.cfsdk.client.dto.Target>();
 

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -193,7 +193,7 @@ namespace ff_server_sdk_test.api.analytics
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
 
-            Assert.IsTrue(AnalyticsPublisherService.GlobalTargetSet.ContainsKey(target1), "Target should be pushed to GlobalTargetSet");
+            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.ContainsKey(target1), "Target should be pushed to GlobalTargetSet");
         }
 
         [Test]
@@ -253,8 +253,7 @@ namespace ff_server_sdk_test.api.analytics
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
             
-            Assert.IsTrue(AnalyticsPublisherService.GlobalTargetSet.Count == 31);
-
+            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 31);
         }
 
         

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -235,6 +235,13 @@ namespace ff_server_sdk_test.api.analytics
                     .Attributes(new Dictionary<string, string>(){{"email", $"demo{i}@harness.io"}})
                     .build();
                 
+                var differentIdentifierAndAttributesToTarget1 = io.harness.cfsdk.client.dto.Target.builder()
+                    .Name($"unique_names_{i}")
+                    .Identifier($"another_different_identifier_{i}")
+                    .Attributes(new Dictionary<string, string>(){{"email", $"12456demo{i}@harness.io"}})
+                    .build();
+
+                
         
                 var task = Task.Run(() =>
                 {
@@ -244,6 +251,7 @@ namespace ff_server_sdk_test.api.analytics
                     metricsProcessor.PushToCache(sameAsTarget1, featureConfig, variation);
                     metricsProcessor.PushToCache(differentAttributesToTarget1, featureConfig, variation);
                     metricsProcessor.PushToCache(differentIdentifierToTarget1, featureConfig, variation);
+                    metricsProcessor.PushToCache(differentIdentifierAndAttributesToTarget1, featureConfig, variation);
                 });
                 tasks.Add(task);
             }
@@ -253,7 +261,7 @@ namespace ff_server_sdk_test.api.analytics
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
             
-            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 31);
+            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 41);
         }
 
         

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -240,9 +240,7 @@ namespace ff_server_sdk_test.api.analytics
                     .Identifier($"another_different_identifier_{i}")
                     .Attributes(new Dictionary<string, string>(){{"email", $"12456demo{i}@harness.io"}})
                     .build();
-
                 
-        
                 var task = Task.Run(() =>
                 {
                     var featureConfig = CreateFeatureConfig($"feature{i}");

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -24,23 +24,23 @@ namespace ff_server_sdk_test.api.analytics
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-
+        
             var variation = new Variation();
             var target = new io.harness.cfsdk.client.dto.Target();
-
+        
             var featureConfig1 = CreateFeatureConfig("feature1");
             var analytics = new Analytics(featureConfig1, target, variation, EventType.METRICS);
-
+        
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-
+        
             // Act
             sut.PushToCache(target, featureConfig1, variation);
-
+        
             // Assert
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(1)); ;
             Assert.That(analyticsCacheMock.getIfPresent(analytics), Is.EqualTo(1));
         }
-
+        
         [Test]
         public void Should_add_multiple_evaluations_for_single_feature_to_analytics_cache()
         {
@@ -48,29 +48,28 @@ namespace ff_server_sdk_test.api.analytics
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-
+        
             var target = new io.harness.cfsdk.client.dto.Target();
             var variation = new Variation();
-
+        
             // simulate multiple evaluations for a single feature
             var featureConfig = CreateFeatureConfig("feature1");
             var analytics = new Analytics(featureConfig, target, variation, EventType.METRICS);
-
+        
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-
+        
             // Act
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
-
+        
             // Assert
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(1));
             Assert.That(analyticsCacheMock.getIfPresent(analytics), Is.EqualTo(5));
-
         }
-
+        
         [Test]
         public void Should_add_single_evaluation_for_multiple_features_to_analytics_cache()
         {
@@ -78,30 +77,30 @@ namespace ff_server_sdk_test.api.analytics
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-
+        
             var target = new io.harness.cfsdk.client.dto.Target();
             var variation = new Variation();
-
+        
             // simulate an evaluation for multiple different features
             var featureConfig1 = CreateFeatureConfig("feature1");
             var featureConfig2 = CreateFeatureConfig("feature2");
-
+        
             var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
             var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
-
+        
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-
+        
             // Act
             sut.PushToCache(target, featureConfig1, variation);
             sut.PushToCache(target, featureConfig2, variation);
-
+        
             // Assert
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
             Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(1));
             Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(1));
         }
-
-
+        
+        
         [Test]
         public void Should_add_multiple_evaluations_for_multiple_features_to_analytics_cache()
         {
@@ -109,55 +108,55 @@ namespace ff_server_sdk_test.api.analytics
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-
+        
             var target = new io.harness.cfsdk.client.dto.Target();
             var variation = new Variation();
-
+        
             // simulate an evaluation for multiple different features
             var featureConfig1 = CreateFeatureConfig("feature1");
             var featureConfig2 = CreateFeatureConfig("feature2");
-
+        
             var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
             var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
-
+        
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-
+        
             // Act
             sut.PushToCache(target, featureConfig1, variation);
             sut.PushToCache(target, featureConfig1, variation);
-
+        
             sut.PushToCache(target, featureConfig2, variation);
             sut.PushToCache(target, featureConfig2, variation);
             sut.PushToCache(target, featureConfig2, variation);
-
+        
             // Assert
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
             Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(2));
             Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(3));
         }
-
+        
         [Test]
         public void Should_force_push_metrics_and_clear_cache_when_analytics_cache_full()
         {
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-
+        
             var bufferSize = 2;
             var configMock = new Config("", "", false, 10, true, 1, bufferSize, 10, 10, 10, false, 10000);
             var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-
+        
             var target = new io.harness.cfsdk.client.dto.Target();
             var variation = new Variation();
-
+        
             var sut = new MetricsProcessor(configMock, analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-
+        
             // Act - set cachesize > buffer
             sut.PushToCache(target, CreateFeatureConfig("feature1"), variation);
             sut.PushToCache(target, CreateFeatureConfig("feature2"), variation);
             sut.PushToCache(target, CreateFeatureConfig("feature3"), variation);
             sut.PushToCache(target, CreateFeatureConfig("feature4"), variation);
-
+        
             // Assert 
             connectorMock.Verify(a => a.PostMetrics(It.IsAny<Metrics>()), Times.Once);
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(0));
@@ -177,17 +176,24 @@ namespace ff_server_sdk_test.api.analytics
                 .Identifier("unique_identifier_1")
                 .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
                 .build();
+            
+            var sameAsTarget1 = io.harness.cfsdk.client.dto.Target.builder()
+                .Name("unique_name_1")
+                .Identifier("unique_identifier_1")
+                .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
+                .build();
+            
 
             var featureConfig1 = CreateFeatureConfig("feature1");
             var variation1 = new Variation();
 
             metricsProcessor.PushToCache(target1, featureConfig1, variation1);
+            metricsProcessor.PushToCache(sameAsTarget1, featureConfig1, variation1);
 
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
 
-            var targetExistsInGlobalSet = AnalyticsPublisherService.GlobalTargetSet.ContainsKey(target1);
-            Assert.IsTrue(targetExistsInGlobalSet, "Target should be pushed to GlobalTargetSet");
+            Assert.IsTrue(AnalyticsPublisherService.GlobalTargetSet.ContainsKey(target1), "Target should be pushed to GlobalTargetSet");
         }
 
         [Test]
@@ -198,13 +204,12 @@ namespace ff_server_sdk_test.api.analytics
             var loggerFactory = new NullLoggerFactory();
             var analyticsPublisherService = new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
             var metricsProcessor = new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
-
+        
             const int numberOfThreads = 10;
             var tasks = new List<Task>();
             var targets = new List<io.harness.cfsdk.client.dto.Target>();
             
-            var duplicateTargets = new List<io.harness.cfsdk.client.dto.Target>();
-
+        
             for (int i = 0; i < numberOfThreads; i++)
             {
                 var target = io.harness.cfsdk.client.dto.Target.builder()
@@ -220,8 +225,8 @@ namespace ff_server_sdk_test.api.analytics
                     .build();
                 
                 targets.Add(target);
-                duplicateTargets.Add(sameAsTarget1);
-
+                targets.Add(sameAsTarget1);
+        
                 var task = Task.Run(() =>
                 {
                     var featureConfig = CreateFeatureConfig($"feature{i}");
@@ -230,24 +235,19 @@ namespace ff_server_sdk_test.api.analytics
                 });
                 tasks.Add(task);
             }
-
+        
             Task.WhenAll(tasks).Wait();
-
+        
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
-
+        
             foreach (var target in targets)
             {
                 var targetExistsInGlobalSet = AnalyticsPublisherService.GlobalTargetSet.ContainsKey(target);
                 Assert.IsTrue(targetExistsInGlobalSet, $"Target {target.Identifier} should be pushed to GlobalTargetSet");
                 Assert.IsTrue(AnalyticsPublisherService.GlobalTargetSet.Count == 11);
             }
-            
-            foreach (var duplicateTarget in duplicateTargets)
-            {
-                var targetExistsInGlobalSet = AnalyticsPublisherService.GlobalTargetSet.ContainsKey(duplicateTarget);
-                Assert.IsFalse(targetExistsInGlobalSet, $"Target {duplicateTarget.Identifier} should not be pushed to GlobalTargetSet");
-            }
+
         }
 
         

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -232,7 +232,7 @@ namespace ff_server_sdk_test.api.analytics
                 var differentIdentifierToTarget1 = io.harness.cfsdk.client.dto.Target.builder()
                     .Name($"unique_names_{i}")
                     .Identifier($"different_identifier_{i}")
-                    .Attributes(new Dictionary<string, string>(){{"email", $"demw2222o{i}@harness.io"}})
+                    .Attributes(new Dictionary<string, string>(){{"email", $"demo{i}@harness.io"}})
                     .build();
                 
         


### PR DESCRIPTION
# What

-  Uses thread safe dictionaries for the targets collections instead of unsafe HashSet which could result in thread contention exceptions

- Fixes duplicate targets being sent and stored. Targets are now equal if their identifier and attributes are the same.

# Testing
- New unit tests
- Manual 
- TestGrid metrics