### PR TITLE
FFM-10410 - Upgrade wiremock

### DIFF
--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="NuGet.Frameworks" Version="6.5.1" /> <!-- Fixes CVE 2023-29337 -->
     <PackageReference Include="WireMock.Net" Version="1.5.36" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="WireMock.Net.FluentAssertions" Version="1.5.35" />
+    <PackageReference Include="WireMock.Net.FluentAssertions" Version="1.5.46" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>

--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NuGet.Frameworks" Version="6.5.1" /> <!-- Fixes CVE 2023-29337 -->
-    <PackageReference Include="WireMock.Net" Version="1.5.36" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
+    <PackageReference Include="WireMock.Net" Version="1.5.46" />
     <PackageReference Include="WireMock.Net.FluentAssertions" Version="1.5.46" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />


### PR DESCRIPTION
**What**
Upgrade wiremock.net.fluentassertions to 1.5.46

**Why**
STO is reporting vulnerabilities on the pipelines are breaking the build check if updating to .46 removes CVE-2020-27853

**Testing**
Manual