### PR TITLE
FFM-10602 Separate `Analytics` into `EvaluationAnalytics` and `TargetAnalytics` 

### DIFF
--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -80,7 +80,8 @@ namespace io.harness.cfsdk.client.api
             this.polling = new PollingProcessor(connector, this.repository, config, this, loggerFactory);
             this.update = new UpdateProcessor(connector, this.repository, config, this, loggerFactory);
             this.evaluator = new Evaluator(this.repository, this, loggerFactory);
-            this.metric = new MetricsProcessor(config, analyticsCache, new AnalyticsPublisherService(connector, analyticsCache, loggerFactory), loggerFactory);
+            // Since 1.4.2, we enable the global target for evaluation metrics. 
+            this.metric = new MetricsProcessor(config, analyticsCache, new AnalyticsPublisherService(connector, analyticsCache, loggerFactory), loggerFactory, true);
             Start();
         }
         internal void Start()

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -84,9 +84,13 @@ namespace io.harness.cfsdk.client.api.analytics
         
         private void PushToTargetAnalyticsCache(Target target)
         {
-            Analytics evaluationAnalytics = new TargetAnalytics(target);
-            var evaluationCount = analyticsCache.getIfPresent(evaluationAnalytics);
-            analyticsCache.Put(evaluationAnalytics, evaluationCount + 1);
+            Analytics targetAnalytics = new TargetAnalytics(target);
+            
+            // We don't need to keep count of targets, so use a constant value, 1, for the count. 
+            // Since 1.4.2, the analytics cache was refactored to separate out Evaluation and Target metrics, but the 
+            // change did not go as far as to maintain two caches (due to effort involved), but differentiate them based on subclassing, so 
+            // the counter used for target metrics isn't needed, but causes no issue. 
+            analyticsCache.Put(targetAnalytics, 1);
         }
 
         internal void Timer_Elapsed(object sender, ElapsedEventArgs e)

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -64,25 +64,29 @@ namespace io.harness.cfsdk.client.api.analytics
             }
             else
             {
-                // Create evaluation metrics
-                // Since 1.4.2, we use the global target identifier for evaluation metrics. 
-                var evaluationAnalytics = createEvaluationAnalytics(featureConfig, variation);
+                PushToEvaluationAnalyticsCache(featureConfig, variation);
 
                 // Create target metrics 
-                Analytics targetAnalytics = new TargetAnalytics(target);
-                var count = analyticsCache.getIfPresent(evaluationAnalytics);
+                PushToTargetAnalyticsCache(target);
 
             }
         }
 
-        private Analytics createEvaluationAnalytics(FeatureConfig featureConfig, Variation variation)
+        private void PushToEvaluationAnalyticsCache(FeatureConfig featureConfig, Variation variation)
         {
+            // Since 1.4.2, we use the global target identifier for evaluation metrics. 
             var globalTarget = new Target(EvaluationAnalytics.GlobalTargetIdentifier,
                 EvaluationAnalytics.GlobalTargetName, null);
             Analytics evaluationAnalytics = new EvaluationAnalytics(featureConfig, variation, globalTarget);
             var evaluationCount = analyticsCache.getIfPresent(evaluationAnalytics);
             analyticsCache.Put(evaluationAnalytics, evaluationCount + 1);
-            return evaluationAnalytics;
+        }
+        
+        private void PushToTargetAnalyticsCache(Target target)
+        {
+            Analytics evaluationAnalytics = new TargetAnalytics(target);
+            var evaluationCount = analyticsCache.getIfPresent(evaluationAnalytics);
+            analyticsCache.Put(evaluationAnalytics, evaluationCount + 1);
         }
 
         internal void Timer_Elapsed(object sender, ElapsedEventArgs e)

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -76,9 +76,9 @@ namespace io.harness.cfsdk.client.api.analytics
                 var analytics = entry.Key;
                 var count = entry.Value;
 
+                // Handle EvaluationAnalytics
                 if (analytics is EvaluationAnalytics evaluationAnalytics)
                 {
-                    // Handle Evaluation Analytics
                     var metricsData = new MetricsData();
                     metricsData.Timestamp = GetCurrentUnixTimestampMillis();
                     metricsData.Count = count;
@@ -93,6 +93,8 @@ namespace io.harness.cfsdk.client.api.analytics
                     StagingSeenTargets.TryAdd(evaluationAnalytics.Target, 0);
                     metrics.MetricsData.Add(metricsData);
                 }
+
+                // Handle TargetAnalytics
                 else if (analytics is TargetAnalytics targetAnalytics)
                 {
                     var target = targetAnalytics.Target;
@@ -102,18 +104,14 @@ namespace io.harness.cfsdk.client.api.analytics
                         {
                             Identifier = target.Identifier,
                             Name = target.Name,
-                            Attributes = new List<KeyValue>(),
+                            Attributes = new List<KeyValue>()
                         };
 
                         // Add target attributes, respecting private attributes
                         foreach (var attribute in target.Attributes)
-                        {
                             if (target.PrivateAttributes == null || !target.PrivateAttributes.Contains(attribute.Key))
-                            {
                                 targetData.Attributes.Add(new KeyValue
                                     { Key = attribute.Key, Value = attribute.Value });
-                            }
-                        }
 
                         // Add to StagingSeenTargets for future reference
                         StagingSeenTargets.TryAdd(target, 0);

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -90,7 +90,7 @@ namespace io.harness.cfsdk.client.api.analytics
                     SetMetricsAttributes(metricsData, VariationValueAttribute, evaluationAnalytics.Variation.Value);
                     SetMetricsAttributes(metricsData, TargetAttribute, evaluationAnalytics.Target.Identifier);
                     SetCommonSdkAttributes(metricsData);
-
+                    StagingSeenTargets.TryAdd(evaluationAnalytics.Target, 0);
                     metrics.MetricsData.Add(metricsData);
                 }
                 else if (analytics is TargetAnalytics targetAnalytics)

--- a/client/dto/Analytics.cs
+++ b/client/dto/Analytics.cs
@@ -30,8 +30,8 @@ namespace io.harness.cfsdk.client.dto
     {
         // The global target is used when we don't want to use the actual target in the evaluation metrics
         // payload.  Since 1.4.2 the global target has been used.
-        private static readonly string GlobalTargetIdentifier = "__global__cf_target";
-        private static readonly string GlobalTargetName = "Global Target";
+        public static readonly string GlobalTargetIdentifier = "__global__cf_target";
+        public static readonly string GlobalTargetName = "Global Target";
         private readonly FeatureConfig featureConfig;
         private readonly Variation variation;
 

--- a/client/dto/Analytics.cs
+++ b/client/dto/Analytics.cs
@@ -32,29 +32,31 @@ namespace io.harness.cfsdk.client.dto
         // payload.  Since 1.4.2 the global target has been used.
         public static readonly string GlobalTargetIdentifier = "__global__cf_target";
         public static readonly string GlobalTargetName = "Global Target";
-        private readonly FeatureConfig featureConfig;
-        private readonly Variation variation;
 
         public EvaluationAnalytics(FeatureConfig featureConfig, Variation variation, Target target)
             : base(target)
         {
-            this.featureConfig = featureConfig;
-            this.variation = variation;
+            this.FeatureConfig = featureConfig;
+            this.Variation = variation;
         }
+        
+        public FeatureConfig FeatureConfig { get; }
+
+        public Variation Variation { get; }
 
 
         public override bool Equals(Analytics other)
         {
             return other is EvaluationAnalytics otherEvaluation
-                   && EqualityComparer<FeatureConfig>.Default.Equals(featureConfig, otherEvaluation.featureConfig)
-                   && EqualityComparer<Variation>.Default.Equals(variation, otherEvaluation.variation);
+                   && EqualityComparer<FeatureConfig>.Default.Equals(FeatureConfig, otherEvaluation.FeatureConfig)
+                   && EqualityComparer<Variation>.Default.Equals(Variation, otherEvaluation.Variation);
         }
 
         public override int GetHashCode()
         {
             var hashCode = -1526478203;
-            hashCode = hashCode * -1521134295 + EqualityComparer<FeatureConfig>.Default.GetHashCode(featureConfig);
-            hashCode = hashCode * -1521134295 + EqualityComparer<Variation>.Default.GetHashCode(variation);
+            hashCode = hashCode * -1521134295 + EqualityComparer<FeatureConfig>.Default.GetHashCode(FeatureConfig);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Variation>.Default.GetHashCode(Variation);
             return hashCode;
         }
 

--- a/client/dto/Analytics.cs
+++ b/client/dto/Analytics.cs
@@ -39,7 +39,7 @@ namespace io.harness.cfsdk.client.dto
             FeatureConfig = featureConfig;
             Variation = variation;
         }
-        
+
         public FeatureConfig FeatureConfig { get; }
 
         public Variation Variation { get; }
@@ -66,14 +66,9 @@ namespace io.harness.cfsdk.client.dto
 // TargetAnalytics subclass
     public class TargetAnalytics : Analytics
     {
-        private readonly Target target;
-
-        // Properties...
-
         public TargetAnalytics(Target target)
             : base(target)
         {
-            // Initialization...
         }
 
         public override bool Equals(Analytics other)

--- a/client/dto/Analytics.cs
+++ b/client/dto/Analytics.cs
@@ -4,43 +4,130 @@ using io.harness.cfsdk.HarnessOpenAPIService;
 
 namespace io.harness.cfsdk.client.dto
 {
-    public class Analytics : IEquatable<Analytics>
+// Base Analytics class
+    public abstract class Analytics : IEquatable<Analytics>
     {
-        private readonly FeatureConfig featureConfig;
-        private readonly Target target;
-        private readonly Variation variation;
+        protected readonly Target target;
 
-        public FeatureConfig FeatureConfig { get => featureConfig; }
-        public Target Target { get => target; }
-        public Variation Variation { get => variation; }
-
-        public Analytics(FeatureConfig featureConfig, Target target, Variation variation, EventType eventType)
+        protected Analytics(Target target)
         {
-            this.featureConfig = featureConfig;
             this.target = target;
-            this.variation = variation;
         }
+
+        public Target Target => target;
+        public abstract bool Equals(Analytics other);
 
         public override bool Equals(object obj)
         {
             return Equals(obj as Analytics);
         }
 
-        public bool Equals(Analytics other)
+        public abstract override int GetHashCode();
+    }
+
+// EvaluationAnalytics subclass
+    public class EvaluationAnalytics : Analytics
+    {
+        // The global target is used when we don't want to use the actual target in the evaluation metrics
+        // payload.  Since 1.4.2 the global target has been used.
+        private static readonly string GlobalTargetIdentifier = "__global__cf_target";
+        private static readonly string GlobalTargetName = "Global Target";
+        private readonly FeatureConfig featureConfig;
+        private readonly Variation variation;
+
+        public EvaluationAnalytics(FeatureConfig featureConfig, Variation variation, Target target)
+            : base(target)
         {
-            return other != null &&
-                   EqualityComparer<FeatureConfig>.Default.Equals(featureConfig, other.featureConfig) &&
-                   EqualityComparer<Target>.Default.Equals(target, other.target) &&
-                   EqualityComparer<Variation>.Default.Equals(variation, other.variation);
+            this.featureConfig = featureConfig;
+            this.variation = variation;
+        }
+
+
+        public override bool Equals(Analytics other)
+        {
+            return other is EvaluationAnalytics otherEvaluation
+                   && EqualityComparer<FeatureConfig>.Default.Equals(featureConfig, otherEvaluation.featureConfig)
+                   && EqualityComparer<Variation>.Default.Equals(variation, otherEvaluation.variation);
         }
 
         public override int GetHashCode()
         {
-            int hashCode = -1526478203;
+            var hashCode = -1526478203;
             hashCode = hashCode * -1521134295 + EqualityComparer<FeatureConfig>.Default.GetHashCode(featureConfig);
-            hashCode = hashCode * -1521134295 + EqualityComparer<Target>.Default.GetHashCode(target);
             hashCode = hashCode * -1521134295 + EqualityComparer<Variation>.Default.GetHashCode(variation);
             return hashCode;
         }
+
+        // Additional methods...
     }
+
+// TargetAnalytics subclass
+    public class TargetAnalytics : Analytics
+    {
+        private readonly Target target;
+
+        // Properties...
+
+        public TargetAnalytics(Target target)
+            : base(target)
+        {
+            // Initialization...
+        }
+
+        public override bool Equals(Analytics other)
+        {
+            return other is TargetAnalytics otherTarget
+                   && EqualityComparer<Target>.Default.Equals(target, otherTarget.target);
+        }
+
+        public override int GetHashCode()
+        {
+            return EqualityComparer<Target>.Default.GetHashCode(target);
+        }
+
+        // Additional methods...
+    }
+
+// Usage in caches and other operations remains the same
+
+
+    // public class Analytics : IEquatable<Analytics>
+    // {
+    //     private readonly FeatureConfig featureConfig;
+    //     private readonly Target target;
+    //     private readonly Variation variation;
+    //
+    //     public FeatureConfig FeatureConfig { get => featureConfig; }
+    //     public Target Target { get => target; }
+    //     public Variation Variation { get => variation; }
+    //
+    //     public Analytics(FeatureConfig featureConfig, Target target, Variation variation, EventType eventType)
+    //     {
+    //         this.featureConfig = featureConfig;
+    //         this.target = target;
+    //         this.variation = variation;
+    //     }
+    //
+    //     public override bool Equals(object obj)
+    //     {
+    //         return Equals(obj as Analytics);
+    //     }
+    //
+    //     public bool Equals(Analytics other)
+    //     {
+    //         return other != null &&
+    //                EqualityComparer<FeatureConfig>.Default.Equals(featureConfig, other.featureConfig) &&
+    //                EqualityComparer<Target>.Default.Equals(target, other.target) &&
+    //                EqualityComparer<Variation>.Default.Equals(variation, other.variation);
+    //     }
+    //
+    //     public override int GetHashCode()
+    //     {
+    //         int hashCode = -1526478203;
+    //         hashCode = hashCode * -1521134295 + EqualityComparer<FeatureConfig>.Default.GetHashCode(featureConfig);
+    //         hashCode = hashCode * -1521134295 + EqualityComparer<Target>.Default.GetHashCode(target);
+    //         hashCode = hashCode * -1521134295 + EqualityComparer<Variation>.Default.GetHashCode(variation);
+    //         return hashCode;
+    //     }
+    // }
 }

--- a/client/dto/Analytics.cs
+++ b/client/dto/Analytics.cs
@@ -4,7 +4,10 @@ using io.harness.cfsdk.HarnessOpenAPIService;
 
 namespace io.harness.cfsdk.client.dto
 {
-// Base Analytics class
+    // We send two types of analytics to the metrics service
+    // 1. Evaluation metrics.
+    // 2. Target metrics.
+    // Both types inherit from this base class.
     public abstract class Analytics : IEquatable<Analytics>
     {
         protected readonly Target target;
@@ -29,7 +32,7 @@ namespace io.harness.cfsdk.client.dto
     public class EvaluationAnalytics : Analytics
     {
         // The global target is used when we don't want to use the actual target in the evaluation metrics
-        // payload.  Since 1.4.2 the global target has been used.
+        // payload. 
         public static readonly string GlobalTargetIdentifier = "__global__cf_target";
         public static readonly string GlobalTargetName = "Global Target";
 

--- a/client/dto/Analytics.cs
+++ b/client/dto/Analytics.cs
@@ -51,6 +51,8 @@ namespace io.harness.cfsdk.client.dto
         public override bool Equals(Analytics other)
         {
             return other is EvaluationAnalytics otherEvaluation
+                   // && EqualityComparer<Target>.Default.Equals(target, otherEvaluation.target)
+                   && EqualityComparer<Target>.Default.Equals(target, otherEvaluation.target)
                    && EqualityComparer<FeatureConfig>.Default.Equals(FeatureConfig, otherEvaluation.FeatureConfig)
                    && EqualityComparer<Variation>.Default.Equals(Variation, otherEvaluation.Variation);
         }
@@ -59,6 +61,7 @@ namespace io.harness.cfsdk.client.dto
         {
             var hashCode = -1526478203;
             hashCode = hashCode * -1521134295 + EqualityComparer<FeatureConfig>.Default.GetHashCode(FeatureConfig);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Target>.Default.GetHashCode(target);
             hashCode = hashCode * -1521134295 + EqualityComparer<Variation>.Default.GetHashCode(Variation);
             return hashCode;
         }

--- a/client/dto/Analytics.cs
+++ b/client/dto/Analytics.cs
@@ -62,8 +62,6 @@ namespace io.harness.cfsdk.client.dto
             hashCode = hashCode * -1521134295 + EqualityComparer<Variation>.Default.GetHashCode(Variation);
             return hashCode;
         }
-
-        // Additional methods...
     }
 
 // TargetAnalytics subclass
@@ -84,50 +82,5 @@ namespace io.harness.cfsdk.client.dto
         {
             return EqualityComparer<Target>.Default.GetHashCode(target);
         }
-
-        // Additional methods...
     }
-
-// Usage in caches and other operations remains the same
-
-
-    // public class Analytics : IEquatable<Analytics>
-    // {
-    //     private readonly FeatureConfig featureConfig;
-    //     private readonly Target target;
-    //     private readonly Variation variation;
-    //
-    //     public FeatureConfig FeatureConfig { get => featureConfig; }
-    //     public Target Target { get => target; }
-    //     public Variation Variation { get => variation; }
-    //
-    //     public Analytics(FeatureConfig featureConfig, Target target, Variation variation, EventType eventType)
-    //     {
-    //         this.featureConfig = featureConfig;
-    //         this.target = target;
-    //         this.variation = variation;
-    //     }
-    //
-    //     public override bool Equals(object obj)
-    //     {
-    //         return Equals(obj as Analytics);
-    //     }
-    //
-    //     public bool Equals(Analytics other)
-    //     {
-    //         return other != null &&
-    //                EqualityComparer<FeatureConfig>.Default.Equals(featureConfig, other.featureConfig) &&
-    //                EqualityComparer<Target>.Default.Equals(target, other.target) &&
-    //                EqualityComparer<Variation>.Default.Equals(variation, other.variation);
-    //     }
-    //
-    //     public override int GetHashCode()
-    //     {
-    //         int hashCode = -1526478203;
-    //         hashCode = hashCode * -1521134295 + EqualityComparer<FeatureConfig>.Default.GetHashCode(featureConfig);
-    //         hashCode = hashCode * -1521134295 + EqualityComparer<Target>.Default.GetHashCode(target);
-    //         hashCode = hashCode * -1521134295 + EqualityComparer<Variation>.Default.GetHashCode(variation);
-    //         return hashCode;
-    //     }
-    // }
 }

--- a/client/dto/Analytics.cs
+++ b/client/dto/Analytics.cs
@@ -28,7 +28,7 @@ namespace io.harness.cfsdk.client.dto
         public abstract override int GetHashCode();
     }
 
-// EvaluationAnalytics subclass
+    // EvaluationAnalytics subclass
     public class EvaluationAnalytics : Analytics
     {
         // The global target is used when we don't want to use the actual target in the evaluation metrics
@@ -64,7 +64,7 @@ namespace io.harness.cfsdk.client.dto
         }
     }
 
-// TargetAnalytics subclass
+    // TargetAnalytics subclass
     public class TargetAnalytics : Analytics
     {
         public TargetAnalytics(Target target)

--- a/client/dto/Analytics.cs
+++ b/client/dto/Analytics.cs
@@ -36,8 +36,8 @@ namespace io.harness.cfsdk.client.dto
         public EvaluationAnalytics(FeatureConfig featureConfig, Variation variation, Target target)
             : base(target)
         {
-            this.FeatureConfig = featureConfig;
-            this.Variation = variation;
+            FeatureConfig = featureConfig;
+            Variation = variation;
         }
         
         public FeatureConfig FeatureConfig { get; }

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.4.1</Version>
+        <Version>1.4.2</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.4.1</PackageVersion>
-        <AssemblyVersion>1.4.1</AssemblyVersion>
+        <PackageVersion>1.4.2</PackageVersion>
+        <AssemblyVersion>1.4.2</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2023</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -18,7 +18,7 @@ namespace ff_server_sdk_test.api.analytics
     public class AnalyticsManagerTests
     {
         [Test]
-        public void Should_add_single_evaluation_for_single_feature_to_analytics_cache()
+        public void Should_add_single_evaluation_and_target_for_single_feature_to_analytics_cache()
         {
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
@@ -29,7 +29,8 @@ namespace ff_server_sdk_test.api.analytics
             var target = new io.harness.cfsdk.client.dto.Target();
         
             var featureConfig1 = CreateFeatureConfig("feature1");
-            var analytics = new Analytics(featureConfig1, target, variation, EventType.METRICS);
+            var evaluationAnalytics = new EvaluationAnalytics(featureConfig1, variation, target);
+            var targetAnalytics = new TargetAnalytics(target);
         
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
         
@@ -37,164 +38,165 @@ namespace ff_server_sdk_test.api.analytics
             sut.PushToCache(target, featureConfig1, variation);
         
             // Assert
-            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(1)); ;
-            Assert.That(analyticsCacheMock.getIfPresent(analytics), Is.EqualTo(1));
+            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2)); ;
+            Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
+            Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
         }
-        
-        [Test]
-        public void Should_add_multiple_evaluations_for_single_feature_to_analytics_cache()
-        {
-            // Arrange
-            var analyticsCacheMock = new AnalyticsCache();
-            var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        
-            var target = new io.harness.cfsdk.client.dto.Target();
-            var variation = new Variation();
-        
-            // simulate multiple evaluations for a single feature
-            var featureConfig = CreateFeatureConfig("feature1");
-            var analytics = new Analytics(featureConfig, target, variation, EventType.METRICS);
-        
-            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        
-            // Act
-            sut.PushToCache(target, featureConfig, variation);
-            sut.PushToCache(target, featureConfig, variation);
-            sut.PushToCache(target, featureConfig, variation);
-            sut.PushToCache(target, featureConfig, variation);
-            sut.PushToCache(target, featureConfig, variation);
-        
-            // Assert
-            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(1));
-            Assert.That(analyticsCacheMock.getIfPresent(analytics), Is.EqualTo(5));
-        }
-        
-        [Test]
-        public void Should_add_single_evaluation_for_multiple_features_to_analytics_cache()
-        {
-            // Arrange
-            var analyticsCacheMock = new AnalyticsCache();
-            var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        
-            var target = new io.harness.cfsdk.client.dto.Target();
-            var variation = new Variation();
-        
-            // simulate an evaluation for multiple different features
-            var featureConfig1 = CreateFeatureConfig("feature1");
-            var featureConfig2 = CreateFeatureConfig("feature2");
-        
-            var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
-            var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
-        
-            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        
-            // Act
-            sut.PushToCache(target, featureConfig1, variation);
-            sut.PushToCache(target, featureConfig2, variation);
-        
-            // Assert
-            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
-            Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(1));
-            Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(1));
-        }
-        
-        
-        [Test]
-        public void Should_add_multiple_evaluations_for_multiple_features_to_analytics_cache()
-        {
-            // Arrange
-            var analyticsCacheMock = new AnalyticsCache();
-            var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        
-            var target = new io.harness.cfsdk.client.dto.Target();
-            var variation = new Variation();
-        
-            // simulate an evaluation for multiple different features
-            var featureConfig1 = CreateFeatureConfig("feature1");
-            var featureConfig2 = CreateFeatureConfig("feature2");
-        
-            var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
-            var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
-        
-            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        
-            // Act
-            sut.PushToCache(target, featureConfig1, variation);
-            sut.PushToCache(target, featureConfig1, variation);
-        
-            sut.PushToCache(target, featureConfig2, variation);
-            sut.PushToCache(target, featureConfig2, variation);
-            sut.PushToCache(target, featureConfig2, variation);
-        
-            // Assert
-            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
-            Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(2));
-            Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(3));
-        }
-        
-        [Test]
-        public void Should_force_push_metrics_and_clear_cache_when_analytics_cache_full()
-        {
-            // Arrange
-            var analyticsCacheMock = new AnalyticsCache();
-            var connectorMock = new Mock<IConnector>();
-        
-            var bufferSize = 2;
-            var configMock = new Config("", "", false, 10, true, 1, bufferSize, 10, 10, 10, false, 10000);
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        
-            var target = new io.harness.cfsdk.client.dto.Target();
-            var variation = new Variation();
-        
-            var sut = new MetricsProcessor(configMock, analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        
-            // Act - set cachesize > buffer
-            sut.PushToCache(target, CreateFeatureConfig("feature1"), variation);
-            sut.PushToCache(target, CreateFeatureConfig("feature2"), variation);
-            sut.PushToCache(target, CreateFeatureConfig("feature3"), variation);
-            sut.PushToCache(target, CreateFeatureConfig("feature4"), variation);
-        
-            // Assert 
-            connectorMock.Verify(a => a.PostMetrics(It.IsAny<Metrics>()), Times.Once);
-            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(0));
-        }
-        
-        [Test]
-        public void Should_Push_Targets_To_GlobalTargetSet_Using_MetricsProcessor()
-        {
-            var analyticsCache = new AnalyticsCache();
-            var connectorMock = new Mock<IConnector>();
-            var loggerFactory = new NullLoggerFactory();
-            var analyticsPublisherService = new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
-            var metricsProcessor = new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
-
-            var target1 = io.harness.cfsdk.client.dto.Target.builder()
-                .Name("unique_name_1")
-                .Identifier("unique_identifier_1")
-                .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
-                .build();
-            
-            var sameAsTarget1 = io.harness.cfsdk.client.dto.Target.builder()
-                .Name("unique_name_1")
-                .Identifier("unique_identifier_1")
-                .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
-                .build();
-            
-
-            var featureConfig1 = CreateFeatureConfig("feature1");
-            var variation1 = new Variation();
-
-            metricsProcessor.PushToCache(target1, featureConfig1, variation1);
-            metricsProcessor.PushToCache(sameAsTarget1, featureConfig1, variation1);
-
-            // Trigger the push to GlobalTargetSet
-            analyticsPublisherService.SendDataAndResetCache();
-
-            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.ContainsKey(target1), "Target should be pushed to GlobalTargetSet");
-        }
+        //
+        // [Test]
+        // public void Should_add_multiple_evaluations_for_single_feature_to_analytics_cache()
+        // {
+        //     // Arrange
+        //     var analyticsCacheMock = new AnalyticsCache();
+        //     var connectorMock = new Mock<IConnector>();
+        //     var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+        //
+        //     var target = new io.harness.cfsdk.client.dto.Target();
+        //     var variation = new Variation();
+        //
+        //     // simulate multiple evaluations for a single feature
+        //     var featureConfig = CreateFeatureConfig("feature1");
+        //     var analytics = new Analytics(featureConfig, target, variation, EventType.METRICS);
+        //
+        //     var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
+        //
+        //     // Act
+        //     sut.PushToCache(target, featureConfig, variation);
+        //     sut.PushToCache(target, featureConfig, variation);
+        //     sut.PushToCache(target, featureConfig, variation);
+        //     sut.PushToCache(target, featureConfig, variation);
+        //     sut.PushToCache(target, featureConfig, variation);
+        //
+        //     // Assert
+        //     Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(1));
+        //     Assert.That(analyticsCacheMock.getIfPresent(analytics), Is.EqualTo(5));
+        // }
+        //
+        // [Test]
+        // public void Should_add_single_evaluation_for_multiple_features_to_analytics_cache()
+        // {
+        //     // Arrange
+        //     var analyticsCacheMock = new AnalyticsCache();
+        //     var connectorMock = new Mock<IConnector>();
+        //     var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+        //
+        //     var target = new io.harness.cfsdk.client.dto.Target();
+        //     var variation = new Variation();
+        //
+        //     // simulate an evaluation for multiple different features
+        //     var featureConfig1 = CreateFeatureConfig("feature1");
+        //     var featureConfig2 = CreateFeatureConfig("feature2");
+        //
+        //     var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
+        //     var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
+        //
+        //     var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
+        //
+        //     // Act
+        //     sut.PushToCache(target, featureConfig1, variation);
+        //     sut.PushToCache(target, featureConfig2, variation);
+        //
+        //     // Assert
+        //     Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+        //     Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(1));
+        //     Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(1));
+        // }
+        //
+        //
+        // [Test]
+        // public void Should_add_multiple_evaluations_for_multiple_features_to_analytics_cache()
+        // {
+        //     // Arrange
+        //     var analyticsCacheMock = new AnalyticsCache();
+        //     var connectorMock = new Mock<IConnector>();
+        //     var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+        //
+        //     var target = new io.harness.cfsdk.client.dto.Target();
+        //     var variation = new Variation();
+        //
+        //     // simulate an evaluation for multiple different features
+        //     var featureConfig1 = CreateFeatureConfig("feature1");
+        //     var featureConfig2 = CreateFeatureConfig("feature2");
+        //
+        //     var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
+        //     var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
+        //
+        //     var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
+        //
+        //     // Act
+        //     sut.PushToCache(target, featureConfig1, variation);
+        //     sut.PushToCache(target, featureConfig1, variation);
+        //
+        //     sut.PushToCache(target, featureConfig2, variation);
+        //     sut.PushToCache(target, featureConfig2, variation);
+        //     sut.PushToCache(target, featureConfig2, variation);
+        //
+        //     // Assert
+        //     Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+        //     Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(2));
+        //     Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(3));
+        // }
+        //
+        // [Test]
+        // public void Should_force_push_metrics_and_clear_cache_when_analytics_cache_full()
+        // {
+        //     // Arrange
+        //     var analyticsCacheMock = new AnalyticsCache();
+        //     var connectorMock = new Mock<IConnector>();
+        //
+        //     var bufferSize = 2;
+        //     var configMock = new Config("", "", false, 10, true, 1, bufferSize, 10, 10, 10, false, 10000);
+        //     var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+        //
+        //     var target = new io.harness.cfsdk.client.dto.Target();
+        //     var variation = new Variation();
+        //
+        //     var sut = new MetricsProcessor(configMock, analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
+        //
+        //     // Act - set cachesize > buffer
+        //     sut.PushToCache(target, CreateFeatureConfig("feature1"), variation);
+        //     sut.PushToCache(target, CreateFeatureConfig("feature2"), variation);
+        //     sut.PushToCache(target, CreateFeatureConfig("feature3"), variation);
+        //     sut.PushToCache(target, CreateFeatureConfig("feature4"), variation);
+        //
+        //     // Assert 
+        //     connectorMock.Verify(a => a.PostMetrics(It.IsAny<Metrics>()), Times.Once);
+        //     Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(0));
+        // }
+        //
+        // [Test]
+        // public void Should_Push_Targets_To_GlobalTargetSet_Using_MetricsProcessor()
+        // {
+        //     var analyticsCache = new AnalyticsCache();
+        //     var connectorMock = new Mock<IConnector>();
+        //     var loggerFactory = new NullLoggerFactory();
+        //     var analyticsPublisherService = new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
+        //     var metricsProcessor = new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
+        //
+        //     var target1 = io.harness.cfsdk.client.dto.Target.builder()
+        //         .Name("unique_name_1")
+        //         .Identifier("unique_identifier_1")
+        //         .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
+        //         .build();
+        //     
+        //     var sameAsTarget1 = io.harness.cfsdk.client.dto.Target.builder()
+        //         .Name("unique_name_1")
+        //         .Identifier("unique_identifier_1")
+        //         .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
+        //         .build();
+        //     
+        //
+        //     var featureConfig1 = CreateFeatureConfig("feature1");
+        //     var variation1 = new Variation();
+        //
+        //     metricsProcessor.PushToCache(target1, featureConfig1, variation1);
+        //     metricsProcessor.PushToCache(sameAsTarget1, featureConfig1, variation1);
+        //
+        //     // Trigger the push to GlobalTargetSet
+        //     analyticsPublisherService.SendDataAndResetCache();
+        //
+        //     Assert.IsTrue(AnalyticsPublisherService.SeenTargets.ContainsKey(target1), "Target should be pushed to GlobalTargetSet");
+        // }
 
         [Test]
         public void Should_Handle_Concurrent_Pushes_To_GlobalTargetSet_Correctly()

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -33,7 +33,7 @@ namespace ff_server_sdk_test.api.analytics
             var targetAnalytics = new TargetAnalytics(target);
 
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
-                new NullLoggerFactory());
+                new NullLoggerFactory(), false);
 
 
             sut.PushToCache(target, featureConfig1, variation);
@@ -67,7 +67,7 @@ namespace ff_server_sdk_test.api.analytics
             var targetAnalytics = new TargetAnalytics(target);
 
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
-                new NullLoggerFactory());
+                new NullLoggerFactory(), false);
 
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
@@ -107,7 +107,7 @@ namespace ff_server_sdk_test.api.analytics
             var targetAnalytics = new TargetAnalytics(target);
 
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
-                new NullLoggerFactory());
+                new NullLoggerFactory(), false);
 
             // Act
             sut.PushToCache(target, featureConfig1, variation);
@@ -135,6 +135,8 @@ namespace ff_server_sdk_test.api.analytics
                 new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
 
             var target = new Target();
+            // var target = new Target(EvaluationAnalytics.GlobalTargetIdentifier, EvaluationAnalytics.GlobalTargetName,
+            //     null);
             var variation = new Variation();
 
             // simulate an evaluation for multiple different features
@@ -145,7 +147,7 @@ namespace ff_server_sdk_test.api.analytics
             var evaluationAnalytics2 = new EvaluationAnalytics(featureConfig2, variation, target);
 
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
-                new NullLoggerFactory());
+                new NullLoggerFactory(), false);
 
             // Act
             sut.PushToCache(target, featureConfig1, variation);
@@ -175,8 +177,10 @@ namespace ff_server_sdk_test.api.analytics
             var loggerFactory = new NullLoggerFactory();
             var analyticsPublisherService =
                 new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
+            
+            // Pass true for global target
             var metricsProcessor =
-                new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
+                new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory, true);
 
 
             var target = Target.builder()
@@ -217,9 +221,10 @@ namespace ff_server_sdk_test.api.analytics
             metricsProcessor.PushToCache(differentAttributesToTarget1, featureConfig, variation);
             metricsProcessor.PushToCache(differentIdentifierToTarget1, featureConfig, variation);
             metricsProcessor.PushToCache(differentIdentifierAndAttributesToTarget1, featureConfig, variation);
-
-
-            var evaluationAnalytics = new EvaluationAnalytics(featureConfig, variation, target);
+            
+            Target globalTarget = new Target(EvaluationAnalytics.GlobalTargetIdentifier,
+                EvaluationAnalytics.GlobalTargetName, null);
+            var evaluationAnalytics = new EvaluationAnalytics(featureConfig, variation, globalTarget);
 
             // Ensure the cache total and breakdown of the type of analytics is correct
             Assert.That(analyticsCache.GetAllElements().Count, Is.EqualTo(6));
@@ -247,7 +252,7 @@ namespace ff_server_sdk_test.api.analytics
             var variation = new Variation();
 
             var sut = new MetricsProcessor(configMock, analyticsCacheMock, analyticsPublisherServiceMock,
-                new NullLoggerFactory());
+                new NullLoggerFactory(), false);
 
             // Act - set cachesize > buffer
             sut.PushToCache(target, CreateFeatureConfig("feature1"), variation);
@@ -268,7 +273,7 @@ namespace ff_server_sdk_test.api.analytics
             var analyticsPublisherService =
                 new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
             var metricsProcessor =
-                new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
+                new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory, false);
 
             var target1 = Target.builder()
                 .Name("unique_name_1")
@@ -305,7 +310,7 @@ namespace ff_server_sdk_test.api.analytics
             var analyticsPublisherService =
                 new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
             var metricsProcessor =
-                new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
+                new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory, false);
 
             const int numberOfThreads = 10;
             var tasks = new List<Task>();
@@ -361,7 +366,7 @@ namespace ff_server_sdk_test.api.analytics
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
             var count = AnalyticsPublisherService.SeenTargets.Count;
-            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 42);
+            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 41);
         }
 
 

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -20,7 +20,6 @@ namespace ff_server_sdk_test.api.analytics
         [Test]
         public void Should_add_single_evaluation_and_target_for_single_feature_to_analytics_cache()
         {
-            // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock =
@@ -36,18 +35,16 @@ namespace ff_server_sdk_test.api.analytics
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
                 new NullLoggerFactory());
 
-            // Act
+
             sut.PushToCache(target, featureConfig1, variation);
 
-            // Assert
             // Ensure the cache total and breakdown of the type of analytics is correct
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
-            
             var (evaluationCount, targetCount) = GetAnalyticsTypeCounts(analyticsCacheMock);
             Assert.That(evaluationCount, Is.EqualTo(1), "Incorrect number of EvaluationAnalytics");
             Assert.That(targetCount, Is.EqualTo(1), "Incorrect number of TargetAnalytics");
-            
-            // Ensure the count is correct.
+
+            // Ensure the counter is correct.
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
             Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
         }
@@ -56,7 +53,6 @@ namespace ff_server_sdk_test.api.analytics
         [Test]
         public void Should_add_multiple_evaluations_for_single_feature_to_analytics_cache()
         {
-            // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock =
@@ -73,21 +69,22 @@ namespace ff_server_sdk_test.api.analytics
             var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
                 new NullLoggerFactory());
 
-            // Act
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
 
-            // Assert
 
-            // Evaluation + target entry
+            // Ensure the cache total and breakdown of the type of analytics is correct
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+            var (evaluationCount, targetCount) = GetAnalyticsTypeCounts(analyticsCacheMock);
+            Assert.That(evaluationCount, Is.EqualTo(1), "Incorrect number of EvaluationAnalytics");
+            Assert.That(targetCount, Is.EqualTo(1), "Incorrect number of TargetAnalytics");
 
             // Correct count
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(5));
-            Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(5));
+            Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
         }
 
         [Test]
@@ -116,8 +113,13 @@ namespace ff_server_sdk_test.api.analytics
             sut.PushToCache(target, featureConfig1, variation);
             sut.PushToCache(target, featureConfig2, variation);
 
-            // Assert
-            // Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+            // Ensure the cache total and breakdown of the type of analytics is correct
+            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(3));
+            var (evaluationCount, targetCount) = GetAnalyticsTypeCounts(analyticsCacheMock);
+            Assert.That(evaluationCount, Is.EqualTo(2), "Incorrect number of EvaluationAnalytics");
+            Assert.That(targetCount, Is.EqualTo(1), "Incorrect number of TargetAnalytics");
+            
+            // Ensure the counter is correct
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics2), Is.EqualTo(1));
         }
@@ -419,22 +421,19 @@ namespace ff_server_sdk_test.api.analytics
                 }
             };
         }
-        
+
         private (int evaluationCount, int targetCount) GetAnalyticsTypeCounts(AnalyticsCache cache)
         {
-            int evaluationCount = 0;
-            int targetCount = 0;
+            var evaluationCount = 0;
+            var targetCount = 0;
 
             foreach (var entry in cache.GetAllElements())
-            {
                 if (entry.Key is EvaluationAnalytics)
                     evaluationCount++;
                 else if (entry.Key is TargetAnalytics)
                     targetCount++;
-            }
 
             return (evaluationCount, targetCount);
         }
-
     }
 }

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -78,37 +78,37 @@ namespace ff_server_sdk_test.api.analytics
             Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(5));
         }
         
-        // [Test]
-        // public void Should_add_single_evaluation_for_multiple_features_to_analytics_cache()
-        // {
-        //     // Arrange
-        //     var analyticsCacheMock = new AnalyticsCache();
-        //     var connectorMock = new Mock<IConnector>();
-        //     var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        //
-        //     var target = new io.harness.cfsdk.client.dto.Target();
-        //     var variation = new Variation();
-        //
-        //     // simulate an evaluation for multiple different features
-        //     var featureConfig1 = CreateFeatureConfig("feature1");
-        //     var featureConfig2 = CreateFeatureConfig("feature2");
-        //
-        //     var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
-        //     var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
-        //
-        //     var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        //
-        //     // Act
-        //     sut.PushToCache(target, featureConfig1, variation);
-        //     sut.PushToCache(target, featureConfig2, variation);
-        //
-        //     // Assert
-        //     Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
-        //     Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(1));
-        //     Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(1));
-        // }
-        //
-        //
+        [Test]
+        public void Should_add_single_evaluation_for_multiple_features_to_analytics_cache()
+        {
+            // Arrange
+            var analyticsCacheMock = new AnalyticsCache();
+            var connectorMock = new Mock<IConnector>();
+            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+        
+            var target = new io.harness.cfsdk.client.dto.Target();
+            var variation = new Variation();
+        
+            // simulate an evaluation for multiple different features
+            var featureConfig1 = CreateFeatureConfig("feature1");
+            var featureConfig2 = CreateFeatureConfig("feature2");
+            var evaluationAnalytics = new EvaluationAnalytics(featureConfig1, variation, target);
+            var evaluationAnalytics2 = new EvaluationAnalytics(featureConfig2, variation, target);
+            var targetAnalytics = new TargetAnalytics(target);
+        
+            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
+        
+            // Act
+            sut.PushToCache(target, featureConfig1, variation);
+            sut.PushToCache(target, featureConfig2, variation);
+        
+            // Assert
+            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+            Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(1));
+            Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(1));
+        }
+        
+        
         // [Test]
         // public void Should_add_multiple_evaluations_for_multiple_features_to_analytics_cache()
         // {

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -40,8 +40,14 @@ namespace ff_server_sdk_test.api.analytics
             sut.PushToCache(target, featureConfig1, variation);
 
             // Assert
+            // Ensure the cache total and breakdown of the type of analytics is correct
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
-            ;
+            
+            var (evaluationCount, targetCount) = GetAnalyticsTypeCounts(analyticsCacheMock);
+            Assert.That(evaluationCount, Is.EqualTo(1), "Incorrect number of EvaluationAnalytics");
+            Assert.That(targetCount, Is.EqualTo(1), "Incorrect number of TargetAnalytics");
+            
+            // Ensure the count is correct.
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
             Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
         }
@@ -148,7 +154,8 @@ namespace ff_server_sdk_test.api.analytics
             sut.PushToCache(target, featureConfig2, variation);
 
             // Assert
-            // Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+            // Two evaluations + one target
+            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(3));
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(2));
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics2), Is.EqualTo(3));
         }
@@ -412,5 +419,22 @@ namespace ff_server_sdk_test.api.analytics
                 }
             };
         }
+        
+        private (int evaluationCount, int targetCount) GetAnalyticsTypeCounts(AnalyticsCache cache)
+        {
+            int evaluationCount = 0;
+            int targetCount = 0;
+
+            foreach (var entry in cache.GetAllElements())
+            {
+                if (entry.Key is EvaluationAnalytics)
+                    evaluationCount++;
+                else if (entry.Key is TargetAnalytics)
+                    targetCount++;
+            }
+
+            return (evaluationCount, targetCount);
+        }
+
     }
 }

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -42,36 +42,42 @@ namespace ff_server_sdk_test.api.analytics
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
             Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
         }
-        //
-        // [Test]
-        // public void Should_add_multiple_evaluations_for_single_feature_to_analytics_cache()
-        // {
-        //     // Arrange
-        //     var analyticsCacheMock = new AnalyticsCache();
-        //     var connectorMock = new Mock<IConnector>();
-        //     var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        //
-        //     var target = new io.harness.cfsdk.client.dto.Target();
-        //     var variation = new Variation();
-        //
-        //     // simulate multiple evaluations for a single feature
-        //     var featureConfig = CreateFeatureConfig("feature1");
-        //     var analytics = new Analytics(featureConfig, target, variation, EventType.METRICS);
-        //
-        //     var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        //
-        //     // Act
-        //     sut.PushToCache(target, featureConfig, variation);
-        //     sut.PushToCache(target, featureConfig, variation);
-        //     sut.PushToCache(target, featureConfig, variation);
-        //     sut.PushToCache(target, featureConfig, variation);
-        //     sut.PushToCache(target, featureConfig, variation);
-        //
-        //     // Assert
-        //     Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(1));
-        //     Assert.That(analyticsCacheMock.getIfPresent(analytics), Is.EqualTo(5));
-        // }
-        //
+        
+        [Test]
+        public void Should_add_multiple_evaluations_for_single_feature_to_analytics_cache()
+        {
+            // Arrange
+            var analyticsCacheMock = new AnalyticsCache();
+            var connectorMock = new Mock<IConnector>();
+            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+        
+            var target = new io.harness.cfsdk.client.dto.Target();
+            var variation = new Variation();
+        
+            // simulate multiple evaluations for a single feature
+            var featureConfig = CreateFeatureConfig("feature1");
+            var evaluationAnalytics = new EvaluationAnalytics(featureConfig, variation, target);
+            var targetAnalytics = new TargetAnalytics(target);
+            
+            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
+        
+            // Act
+            sut.PushToCache(target, featureConfig, variation);
+            sut.PushToCache(target, featureConfig, variation);
+            sut.PushToCache(target, featureConfig, variation);
+            sut.PushToCache(target, featureConfig, variation);
+            sut.PushToCache(target, featureConfig, variation);
+        
+            // Assert
+            
+            // Evaluation + target entry
+            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+            
+            // Correct count
+            Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(5));
+            Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(5));
+        }
+        
         // [Test]
         // public void Should_add_single_evaluation_for_multiple_features_to_analytics_cache()
         // {

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -1,4 +1,5 @@
-﻿using io.harness.cfsdk.client.cache;
+﻿using System;
+using io.harness.cfsdk.client.cache;
 using io.harness.cfsdk.client.connector;
 using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.HarnessOpenAPIService;
@@ -42,6 +43,8 @@ namespace ff_server_sdk_test.api.analytics
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
             Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
         }
+        
+    
         
         [Test]
         public void Should_add_multiple_evaluations_for_single_feature_to_analytics_cache()
@@ -103,106 +106,105 @@ namespace ff_server_sdk_test.api.analytics
             sut.PushToCache(target, featureConfig2, variation);
         
             // Assert
-            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
-            Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(1));
-            Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(1));
+            // Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+            Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
+            Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics2), Is.EqualTo(1));
         }
         
         
-        // [Test]
-        // public void Should_add_multiple_evaluations_for_multiple_features_to_analytics_cache()
-        // {
-        //     // Arrange
-        //     var analyticsCacheMock = new AnalyticsCache();
-        //     var connectorMock = new Mock<IConnector>();
-        //     var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        //
-        //     var target = new io.harness.cfsdk.client.dto.Target();
-        //     var variation = new Variation();
-        //
-        //     // simulate an evaluation for multiple different features
-        //     var featureConfig1 = CreateFeatureConfig("feature1");
-        //     var featureConfig2 = CreateFeatureConfig("feature2");
-        //
-        //     var analytics1 = new Analytics(featureConfig1, target, variation, EventType.METRICS);
-        //     var analytics2 = new Analytics(featureConfig2, target, variation, EventType.METRICS);
-        //
-        //     var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        //
-        //     // Act
-        //     sut.PushToCache(target, featureConfig1, variation);
-        //     sut.PushToCache(target, featureConfig1, variation);
-        //
-        //     sut.PushToCache(target, featureConfig2, variation);
-        //     sut.PushToCache(target, featureConfig2, variation);
-        //     sut.PushToCache(target, featureConfig2, variation);
-        //
-        //     // Assert
-        //     Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
-        //     Assert.That(analyticsCacheMock.getIfPresent(analytics1), Is.EqualTo(2));
-        //     Assert.That(analyticsCacheMock.getIfPresent(analytics2), Is.EqualTo(3));
-        // }
-        //
-        // [Test]
-        // public void Should_force_push_metrics_and_clear_cache_when_analytics_cache_full()
-        // {
-        //     // Arrange
-        //     var analyticsCacheMock = new AnalyticsCache();
-        //     var connectorMock = new Mock<IConnector>();
-        //
-        //     var bufferSize = 2;
-        //     var configMock = new Config("", "", false, 10, true, 1, bufferSize, 10, 10, 10, false, 10000);
-        //     var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        //
-        //     var target = new io.harness.cfsdk.client.dto.Target();
-        //     var variation = new Variation();
-        //
-        //     var sut = new MetricsProcessor(configMock, analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        //
-        //     // Act - set cachesize > buffer
-        //     sut.PushToCache(target, CreateFeatureConfig("feature1"), variation);
-        //     sut.PushToCache(target, CreateFeatureConfig("feature2"), variation);
-        //     sut.PushToCache(target, CreateFeatureConfig("feature3"), variation);
-        //     sut.PushToCache(target, CreateFeatureConfig("feature4"), variation);
-        //
-        //     // Assert 
-        //     connectorMock.Verify(a => a.PostMetrics(It.IsAny<Metrics>()), Times.Once);
-        //     Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(0));
-        // }
-        //
-        // [Test]
-        // public void Should_Push_Targets_To_GlobalTargetSet_Using_MetricsProcessor()
-        // {
-        //     var analyticsCache = new AnalyticsCache();
-        //     var connectorMock = new Mock<IConnector>();
-        //     var loggerFactory = new NullLoggerFactory();
-        //     var analyticsPublisherService = new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
-        //     var metricsProcessor = new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
-        //
-        //     var target1 = io.harness.cfsdk.client.dto.Target.builder()
-        //         .Name("unique_name_1")
-        //         .Identifier("unique_identifier_1")
-        //         .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
-        //         .build();
-        //     
-        //     var sameAsTarget1 = io.harness.cfsdk.client.dto.Target.builder()
-        //         .Name("unique_name_1")
-        //         .Identifier("unique_identifier_1")
-        //         .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
-        //         .build();
-        //     
-        //
-        //     var featureConfig1 = CreateFeatureConfig("feature1");
-        //     var variation1 = new Variation();
-        //
-        //     metricsProcessor.PushToCache(target1, featureConfig1, variation1);
-        //     metricsProcessor.PushToCache(sameAsTarget1, featureConfig1, variation1);
-        //
-        //     // Trigger the push to GlobalTargetSet
-        //     analyticsPublisherService.SendDataAndResetCache();
-        //
-        //     Assert.IsTrue(AnalyticsPublisherService.SeenTargets.ContainsKey(target1), "Target should be pushed to GlobalTargetSet");
-        // }
+        [Test]
+        public void Should_add_multiple_evaluations_for_multiple_features_to_analytics_cache()
+        {
+            // Arrange
+            var analyticsCacheMock = new AnalyticsCache();
+            var connectorMock = new Mock<IConnector>();
+            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+        
+            var target = new io.harness.cfsdk.client.dto.Target();
+            var variation = new Variation();
+        
+            // simulate an evaluation for multiple different features
+            var featureConfig1 = CreateFeatureConfig("feature1");
+            var featureConfig2 = CreateFeatureConfig("feature2");
+        
+            var evaluationAnalytics = new EvaluationAnalytics(featureConfig1, variation, target);
+            var evaluationAnalytics2 = new EvaluationAnalytics(featureConfig2, variation, target);
+        
+            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
+        
+            // Act
+            sut.PushToCache(target, featureConfig1, variation);
+            sut.PushToCache(target, featureConfig1, variation);
+        
+            sut.PushToCache(target, featureConfig2, variation);
+            sut.PushToCache(target, featureConfig2, variation);
+            sut.PushToCache(target, featureConfig2, variation);
+        
+            // Assert
+            // Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+            Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(2));
+            Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics2), Is.EqualTo(3));
+        }
+        
+        [Test]
+        public void Should_force_push_metrics_and_clear_cache_when_analytics_cache_full()
+        {
+            // Arrange
+            var analyticsCacheMock = new AnalyticsCache();
+            var connectorMock = new Mock<IConnector>();
+        
+            var bufferSize = 2;
+            var configMock = new Config("", "", false, 10, true, 1, bufferSize, 10, 10, 10, false, 10000);
+            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+        
+            var target = new io.harness.cfsdk.client.dto.Target();
+            var variation = new Variation();
+        
+            var sut = new MetricsProcessor(configMock, analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
+        
+            // Act - set cachesize > buffer
+            sut.PushToCache(target, CreateFeatureConfig("feature1"), variation);
+            sut.PushToCache(target, CreateFeatureConfig("feature2"), variation);
+            sut.PushToCache(target, CreateFeatureConfig("feature3"), variation);
+        
+            // Assert 
+            connectorMock.Verify(a => a.PostMetrics(It.IsAny<Metrics>()), Times.Once);
+            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(0));
+        }
+        
+        [Test]
+        public void Should_Push_Targets_To_GlobalTargetSet_Using_MetricsProcessor()
+        {
+            var analyticsCache = new AnalyticsCache();
+            var connectorMock = new Mock<IConnector>();
+            var loggerFactory = new NullLoggerFactory();
+            var analyticsPublisherService = new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
+            var metricsProcessor = new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
+        
+            var target1 = io.harness.cfsdk.client.dto.Target.builder()
+                .Name("unique_name_1")
+                .Identifier("unique_identifier_1")
+                .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
+                .build();
+            
+            var sameAsTarget1 = io.harness.cfsdk.client.dto.Target.builder()
+                .Name("unique_name_1")
+                .Identifier("unique_identifier_1")
+                .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
+                .build();
+            
+        
+            var featureConfig1 = CreateFeatureConfig("feature1");
+            var variation1 = new Variation();
+        
+            metricsProcessor.PushToCache(target1, featureConfig1, variation1);
+            metricsProcessor.PushToCache(sameAsTarget1, featureConfig1, variation1);
+        
+            // Trigger the push to GlobalTargetSet
+            analyticsPublisherService.SendDataAndResetCache();
+        
+            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.ContainsKey(target1), "Target should be pushed to GlobalTargetSet");
+        }
 
         [Test]
         public void Should_Handle_Concurrent_Pushes_To_GlobalTargetSet_Correctly()
@@ -266,8 +268,8 @@ namespace ff_server_sdk_test.api.analytics
         
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
-            
-            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 41);
+            int count = AnalyticsPublisherService.SeenTargets.Count;
+            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 42);
         }
 
         

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -1,17 +1,16 @@
-﻿using System;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using io.harness.cfsdk.client.api;
+using io.harness.cfsdk.client.api.analytics;
 using io.harness.cfsdk.client.cache;
 using io.harness.cfsdk.client.connector;
 using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.HarnessOpenAPIService;
-using NUnit.Framework;
-using Moq;
-using io.harness.cfsdk.client.api.analytics;
-using io.harness.cfsdk.client.api;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using io.harness.cfsdk.HarnessOpenMetricsAPIService;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Target = io.harness.cfsdk.client.dto.Target;
 
 namespace ff_server_sdk_test.api.analytics
 {
@@ -24,186 +23,269 @@ namespace ff_server_sdk_test.api.analytics
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        
+            var analyticsPublisherServiceMock =
+                new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+
             var variation = new Variation();
-            var target = new io.harness.cfsdk.client.dto.Target();
-        
+            var target = new Target();
+
             var featureConfig1 = CreateFeatureConfig("feature1");
             var evaluationAnalytics = new EvaluationAnalytics(featureConfig1, variation, target);
             var targetAnalytics = new TargetAnalytics(target);
-        
-            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        
+
+            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
+                new NullLoggerFactory());
+
             // Act
             sut.PushToCache(target, featureConfig1, variation);
-        
+
             // Assert
-            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2)); ;
+            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
+            ;
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
             Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
         }
-        
-    
-        
+
+
         [Test]
         public void Should_add_multiple_evaluations_for_single_feature_to_analytics_cache()
         {
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        
-            var target = new io.harness.cfsdk.client.dto.Target();
+            var analyticsPublisherServiceMock =
+                new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+
+            var target = new Target();
             var variation = new Variation();
-        
+
             // simulate multiple evaluations for a single feature
             var featureConfig = CreateFeatureConfig("feature1");
             var evaluationAnalytics = new EvaluationAnalytics(featureConfig, variation, target);
             var targetAnalytics = new TargetAnalytics(target);
-            
-            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        
+
+            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
+                new NullLoggerFactory());
+
             // Act
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
             sut.PushToCache(target, featureConfig, variation);
-        
+
             // Assert
-            
+
             // Evaluation + target entry
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
-            
+
             // Correct count
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(5));
             Assert.That(analyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(5));
         }
-        
+
         [Test]
         public void Should_add_single_evaluation_for_multiple_features_to_analytics_cache()
         {
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        
-            var target = new io.harness.cfsdk.client.dto.Target();
+            var analyticsPublisherServiceMock =
+                new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+
+            var target = new Target();
             var variation = new Variation();
-        
+
             // simulate an evaluation for multiple different features
             var featureConfig1 = CreateFeatureConfig("feature1");
             var featureConfig2 = CreateFeatureConfig("feature2");
             var evaluationAnalytics = new EvaluationAnalytics(featureConfig1, variation, target);
             var evaluationAnalytics2 = new EvaluationAnalytics(featureConfig2, variation, target);
             var targetAnalytics = new TargetAnalytics(target);
-        
-            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        
+
+            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
+                new NullLoggerFactory());
+
             // Act
             sut.PushToCache(target, featureConfig1, variation);
             sut.PushToCache(target, featureConfig2, variation);
-        
+
             // Assert
             // Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics2), Is.EqualTo(1));
         }
-        
-        
+
+
         [Test]
         public void Should_add_multiple_evaluations_for_multiple_features_to_analytics_cache()
         {
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        
-            var target = new io.harness.cfsdk.client.dto.Target();
+            var analyticsPublisherServiceMock =
+                new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+
+            var target = new Target();
             var variation = new Variation();
-        
+
             // simulate an evaluation for multiple different features
             var featureConfig1 = CreateFeatureConfig("feature1");
             var featureConfig2 = CreateFeatureConfig("feature2");
-        
+
             var evaluationAnalytics = new EvaluationAnalytics(featureConfig1, variation, target);
             var evaluationAnalytics2 = new EvaluationAnalytics(featureConfig2, variation, target);
-        
-            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        
+
+            var sut = new MetricsProcessor(new Config(), analyticsCacheMock, analyticsPublisherServiceMock,
+                new NullLoggerFactory());
+
             // Act
             sut.PushToCache(target, featureConfig1, variation);
             sut.PushToCache(target, featureConfig1, variation);
-        
+
             sut.PushToCache(target, featureConfig2, variation);
             sut.PushToCache(target, featureConfig2, variation);
             sut.PushToCache(target, featureConfig2, variation);
-        
+
             // Assert
             // Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(2));
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(2));
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics2), Is.EqualTo(3));
         }
-        
+
+        [Test]
+        public void Should_store_one_evaluation_when_global_target_is_used_for_multiple_evaluations()
+        {
+            var analyticsCache = new AnalyticsCache();
+            var connectorMock = new Mock<IConnector>();
+            var loggerFactory = new NullLoggerFactory();
+            var analyticsPublisherService =
+                new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
+            var metricsProcessor =
+                new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
+
+
+            var target = Target.builder()
+                .Name("unique_name_1")
+                .Identifier("unique_identifier_1")
+                .Attributes(new Dictionary<string, string> { { "email", "demo1@harness.io" } })
+                .build();
+
+            var sameAsTarget1 = Target.builder()
+                .Name("unique_name_2")
+                .Identifier("unique_identifier_2")
+                .Attributes(new Dictionary<string, string> { { "email", "demo2@harness.io" } })
+                .build();
+
+            var differentAttributesToTarget1 = Target.builder()
+                .Name("unique_names_3")
+                .Identifier("unique_identifier_3")
+                .Attributes(new Dictionary<string, string> { { "email", "demo124563@harness.io" } })
+                .build();
+
+            var differentIdentifierToTarget1 = Target.builder()
+                .Name("unique_names_4")
+                .Identifier("different_identifier_4")
+                .Attributes(new Dictionary<string, string> { { "email", "demo4@harness.io" } })
+                .build();
+
+            var differentIdentifierAndAttributesToTarget1 = Target.builder()
+                .Name("unique_names_5")
+                .Identifier("another_different_identifier_5")
+                .Attributes(new Dictionary<string, string> { { "email", "12456demo5@harness.io" } })
+                .build();
+
+
+            var featureConfig = CreateFeatureConfig("feature");
+            var variation = new Variation();
+            metricsProcessor.PushToCache(target, featureConfig, variation);
+            metricsProcessor.PushToCache(sameAsTarget1, featureConfig, variation);
+            metricsProcessor.PushToCache(differentAttributesToTarget1, featureConfig, variation);
+            metricsProcessor.PushToCache(differentIdentifierToTarget1, featureConfig, variation);
+            metricsProcessor.PushToCache(differentIdentifierAndAttributesToTarget1, featureConfig, variation);
+
+
+            var evaluationAnalytics = new EvaluationAnalytics(featureConfig, variation, target);
+
+            var evaluationAnalyticsCount = 0;
+            var targetAnalyticsCount = 0;
+            foreach (var entry in analyticsCache.GetAllElements())
+                if (entry.Key is EvaluationAnalytics)
+                    evaluationAnalyticsCount++;
+                else if (entry.Key is TargetAnalytics) targetAnalyticsCount++;
+            // One unique evaluation
+            Assert.That(evaluationAnalyticsCount, Is.EqualTo(1));
+
+            // Five unique targets
+            Assert.That(targetAnalyticsCount, Is.EqualTo(5));
+
+            // Check the evaluation has a count of 5
+            Assert.That(analyticsCache.getIfPresent(evaluationAnalytics), Is.EqualTo(5));
+        }
+
         [Test]
         public void Should_force_push_metrics_and_clear_cache_when_analytics_cache_full()
         {
             // Arrange
             var analyticsCacheMock = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
-        
+
             var bufferSize = 2;
             var configMock = new Config("", "", false, 10, true, 1, bufferSize, 10, 10, 10, false, 10000);
-            var analyticsPublisherServiceMock = new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-        
-            var target = new io.harness.cfsdk.client.dto.Target();
+            var analyticsPublisherServiceMock =
+                new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
+
+            var target = new Target();
             var variation = new Variation();
-        
-            var sut = new MetricsProcessor(configMock, analyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory());
-        
+
+            var sut = new MetricsProcessor(configMock, analyticsCacheMock, analyticsPublisherServiceMock,
+                new NullLoggerFactory());
+
             // Act - set cachesize > buffer
             sut.PushToCache(target, CreateFeatureConfig("feature1"), variation);
             sut.PushToCache(target, CreateFeatureConfig("feature2"), variation);
             sut.PushToCache(target, CreateFeatureConfig("feature3"), variation);
-        
+
             // Assert 
             connectorMock.Verify(a => a.PostMetrics(It.IsAny<Metrics>()), Times.Once);
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(0));
         }
-        
+
         [Test]
         public void Should_Push_Targets_To_GlobalTargetSet_Using_MetricsProcessor()
         {
             var analyticsCache = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
             var loggerFactory = new NullLoggerFactory();
-            var analyticsPublisherService = new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
-            var metricsProcessor = new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
-        
-            var target1 = io.harness.cfsdk.client.dto.Target.builder()
+            var analyticsPublisherService =
+                new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
+            var metricsProcessor =
+                new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
+
+            var target1 = Target.builder()
                 .Name("unique_name_1")
                 .Identifier("unique_identifier_1")
-                .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
+                .Attributes(new Dictionary<string, string> { { "email", "demo@harness.io" } })
                 .build();
-            
-            var sameAsTarget1 = io.harness.cfsdk.client.dto.Target.builder()
+
+            var sameAsTarget1 = Target.builder()
                 .Name("unique_name_1")
                 .Identifier("unique_identifier_1")
-                .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
+                .Attributes(new Dictionary<string, string> { { "email", "demo@harness.io" } })
                 .build();
-            
-        
+
+
             var featureConfig1 = CreateFeatureConfig("feature1");
             var variation1 = new Variation();
-        
+
             metricsProcessor.PushToCache(target1, featureConfig1, variation1);
             metricsProcessor.PushToCache(sameAsTarget1, featureConfig1, variation1);
-        
+
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
-        
-            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.ContainsKey(target1), "Target should be pushed to GlobalTargetSet");
+
+            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.ContainsKey(target1),
+                "Target should be pushed to GlobalTargetSet");
         }
 
         [Test]
@@ -212,45 +294,47 @@ namespace ff_server_sdk_test.api.analytics
             var analyticsCache = new AnalyticsCache();
             var connectorMock = new Mock<IConnector>();
             var loggerFactory = new NullLoggerFactory();
-            var analyticsPublisherService = new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
-            var metricsProcessor = new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
-        
+            var analyticsPublisherService =
+                new AnalyticsPublisherService(connectorMock.Object, analyticsCache, loggerFactory);
+            var metricsProcessor =
+                new MetricsProcessor(new Config(), analyticsCache, analyticsPublisherService, loggerFactory);
+
             const int numberOfThreads = 10;
             var tasks = new List<Task>();
-            
-        
-            for (int i = 0; i < numberOfThreads; i++)
+
+
+            for (var i = 0; i < numberOfThreads; i++)
             {
-                var target = io.harness.cfsdk.client.dto.Target.builder()
+                var target = Target.builder()
                     .Name($"unique_name_{i}")
                     .Identifier($"unique_identifier_{i}")
-                    .Attributes(new Dictionary<string, string>(){{"email", $"demo{i}@harness.io"}})
+                    .Attributes(new Dictionary<string, string> { { "email", $"demo{i}@harness.io" } })
                     .build();
-                
-                var sameAsTarget1 = io.harness.cfsdk.client.dto.Target.builder()
+
+                var sameAsTarget1 = Target.builder()
                     .Name($"unique_name_{i}")
                     .Identifier($"unique_identifier_{i}")
-                    .Attributes(new Dictionary<string, string>(){{"email", $"demo{i}@harness.io"}})
+                    .Attributes(new Dictionary<string, string> { { "email", $"demo{i}@harness.io" } })
                     .build();
-                
-                var differentAttributesToTarget1 = io.harness.cfsdk.client.dto.Target.builder()
+
+                var differentAttributesToTarget1 = Target.builder()
                     .Name($"unique_names_{i}")
                     .Identifier($"unique_identifier_{i}")
-                    .Attributes(new Dictionary<string, string>(){{"email", $"demo12456{i}@harness.io"}})
+                    .Attributes(new Dictionary<string, string> { { "email", $"demo12456{i}@harness.io" } })
                     .build();
-                
-                var differentIdentifierToTarget1 = io.harness.cfsdk.client.dto.Target.builder()
+
+                var differentIdentifierToTarget1 = Target.builder()
                     .Name($"unique_names_{i}")
                     .Identifier($"different_identifier_{i}")
-                    .Attributes(new Dictionary<string, string>(){{"email", $"demo{i}@harness.io"}})
+                    .Attributes(new Dictionary<string, string> { { "email", $"demo{i}@harness.io" } })
                     .build();
-                
-                var differentIdentifierAndAttributesToTarget1 = io.harness.cfsdk.client.dto.Target.builder()
+
+                var differentIdentifierAndAttributesToTarget1 = Target.builder()
                     .Name($"unique_names_{i}")
                     .Identifier($"another_different_identifier_{i}")
-                    .Attributes(new Dictionary<string, string>(){{"email", $"12456demo{i}@harness.io"}})
+                    .Attributes(new Dictionary<string, string> { { "email", $"12456demo{i}@harness.io" } })
                     .build();
-                
+
                 var task = Task.Run(() =>
                 {
                     var featureConfig = CreateFeatureConfig($"feature{i}");
@@ -263,16 +347,16 @@ namespace ff_server_sdk_test.api.analytics
                 });
                 tasks.Add(task);
             }
-        
+
             Task.WhenAll(tasks).Wait();
-        
+
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
-            int count = AnalyticsPublisherService.SeenTargets.Count;
+            var count = AnalyticsPublisherService.SeenTargets.Count;
             Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 42);
         }
 
-        
+
         private FeatureConfig CreateFeatureConfig(string feature)
         {
             return new FeatureConfig
@@ -284,20 +368,41 @@ namespace ff_server_sdk_test.api.analytics
                 Kind = FeatureConfigKind.Boolean,
                 Variations = new List<Variation>
                 {
-                    new Variation { /* Variation properties */ },
-                    new Variation { /* Variation properties */ }
+                    new()
+                    {
+                        /* Variation properties */
+                    },
+                    new()
+                    {
+                        /* Variation properties */
+                    }
                 },
-                DefaultServe = new Serve { /* Serve properties */ },
+                DefaultServe = new Serve
+                {
+                    /* Serve properties */
+                },
                 OffVariation = "DummyOffVariation",
                 Prerequisites = new List<Prerequisite>
                 {
-                    new Prerequisite { /* Prerequisite properties */ },
-                    new Prerequisite { /* Prerequisite properties */ }
+                    new()
+                    {
+                        /* Prerequisite properties */
+                    },
+                    new()
+                    {
+                        /* Prerequisite properties */
+                    }
                 },
                 VariationToTargetMap = new List<VariationMap>
                 {
-                    new VariationMap { /* VariationMap properties */ },
-                    new VariationMap { /* VariationMap properties */ }
+                    new()
+                    {
+                        /* VariationMap properties */
+                    },
+                    new()
+                    {
+                        /* VariationMap properties */
+                    }
                 },
                 Version = 1,
                 AdditionalProperties = new Dictionary<string, object>
@@ -308,7 +413,4 @@ namespace ff_server_sdk_test.api.analytics
             };
         }
     }
-
-
 }
-

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -155,8 +155,13 @@ namespace ff_server_sdk_test.api.analytics
             sut.PushToCache(target, featureConfig2, variation);
             sut.PushToCache(target, featureConfig2, variation);
 
-            // Assert
-            // Two evaluations + one target
+            // Ensure the cache total and breakdown of the type of analytics is correct
+            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(3));
+            var (evaluationCount, targetCount) = GetAnalyticsTypeCounts(analyticsCacheMock);
+            Assert.That(evaluationCount, Is.EqualTo(2), "Incorrect number of EvaluationAnalytics");
+            Assert.That(targetCount, Is.EqualTo(1), "Incorrect number of TargetAnalytics");
+            
+            // Ensure the counter is correct
             Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(3));
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(2));
             Assert.That(analyticsCacheMock.getIfPresent(evaluationAnalytics2), Is.EqualTo(3));
@@ -216,17 +221,11 @@ namespace ff_server_sdk_test.api.analytics
 
             var evaluationAnalytics = new EvaluationAnalytics(featureConfig, variation, target);
 
-            var evaluationAnalyticsCount = 0;
-            var targetAnalyticsCount = 0;
-            foreach (var entry in analyticsCache.GetAllElements())
-                if (entry.Key is EvaluationAnalytics)
-                    evaluationAnalyticsCount++;
-                else if (entry.Key is TargetAnalytics) targetAnalyticsCount++;
-            // One unique evaluation
-            Assert.That(evaluationAnalyticsCount, Is.EqualTo(1));
-
-            // Five unique targets
-            Assert.That(targetAnalyticsCount, Is.EqualTo(5));
+            // Ensure the cache total and breakdown of the type of analytics is correct
+            Assert.That(analyticsCache.GetAllElements().Count, Is.EqualTo(6));
+            var (evaluationCount, targetCount) = GetAnalyticsTypeCounts(analyticsCache);
+            Assert.That(evaluationCount, Is.EqualTo(1), "Incorrect number of EvaluationAnalytics");
+            Assert.That(targetCount, Is.EqualTo(5), "Incorrect number of TargetAnalytics");
 
             // Check the evaluation has a count of 5
             Assert.That(analyticsCache.getIfPresent(evaluationAnalytics), Is.EqualTo(5));


### PR DESCRIPTION
# What
Previously, we didn't differentiate between `evaluation` and `target` metrics in terms of storing and processing them as separate entities. This meant that we could not use the `global target` feature to shrink `evaluation` metrics. The `global target` feature means that a unique evaluation metric is a combination of unique `flag ` + `variation` values, where as before the `target` would have been used.  
This change separates out the metric types as follows:

1. The original single cache is used. I have not created a separate cache. 
2. The metric types are differentiated using a subclassing approach, where we store each type in the same cache.
3. When we come to process the metrics, we check the type accordingly. 

Also enables global target feature. 

# Testing
- Without `global target` feature
    - Unit tests 
    - Manual testing using sample app

-  With `global target` feature
    - New unit tests
    - Manual testing using sample app