### PR TITLE
FFM-10602 Don't make network request from Evaluation thread

### DIFF
--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -171,8 +171,10 @@ namespace io.harness.cfsdk.client.api
         }
 
         /*
-        BufferSize must be a power of 2 for LMAX to work. This function vaidates
+        BufferSize must be a power of 2 for LMAX to work This function vaidates
         that. Source: https://stackoverflow.com/a/600306/1493480
+        The max BufferSize that can be set is 4096. 
+        Defaults to 2048 if not a power of 2 or over 4096.
         */
         public ConfigBuilder SetBufferSize(int bufferSize)
         {

--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -38,18 +38,8 @@ namespace io.harness.cfsdk.client.api
 
         //BufferSize must be a power of 2 for LMAX to work. This function vaidates
         //that. Source: https://stackoverflow.com/a/600306/1493480
-        public int BufferSize
-        {
-            get
-            {
-                if (!(bufferSize != 0 && ((bufferSize & (bufferSize - 1)) == 0)))
-                {
-                    throw new CfClientException("BufferSize must be a power of 2");
-                }
-                return bufferSize;
-            }
-        }
-        private int bufferSize = 1024;
+        public int BufferSize => bufferSize;
+        internal int bufferSize = 1024;
 
 
         /** timeout in milliseconds to connect to CF Server */
@@ -100,20 +90,7 @@ namespace io.harness.cfsdk.client.api
         {
             return new ConfigBuilder();
         }
-
-        /*
-  BufferSize must be a power of 2 for LMAX to work. This function vaidates
-  that. Source: https://stackoverflow.com/a/600306/1493480
- */
-        public int getBufferSize()
-        {
-            if (!(bufferSize != 0 && ((bufferSize & (bufferSize - 1)) == 0)))
-            {
-                throw new CfClientException("BufferSize must be a power of 2");
-            }
-            return bufferSize;
-        }
-
+        
     }
 
     public class ConfigBuilder
@@ -190,6 +167,25 @@ namespace io.harness.cfsdk.client.api
         public ConfigBuilder debug(bool debug)
         {
             this.configtobuild.debug = debug;
+            return this;
+        }
+
+        /*
+        BufferSize must be a power of 2 for LMAX to work. This function vaidates
+        that. Source: https://stackoverflow.com/a/600306/1493480
+        */
+        public ConfigBuilder SetBufferSize(int bufferSize)
+        {
+            // Check if bufferSize is a power of two
+            var isPowerOfTwo = bufferSize > 0 && (bufferSize & (bufferSize - 1)) == 0;
+
+            if (!isPowerOfTwo || bufferSize > 4096)
+            {
+                // Log a warning if bufferSize is not a power of two or if it's greater than 4096
+                bufferSize = 2048; // Set default value
+            }
+
+            configtobuild.bufferSize = bufferSize;
             return this;
         }
 

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -30,13 +30,15 @@ namespace io.harness.cfsdk.client.api
         private readonly ILoggerFactory loggerFactory;
         private readonly IRepository repository;
         private readonly IEvaluatorCallback callback;
+        private readonly bool IsAnalyticsEnabled;
 
-        public Evaluator(IRepository repository, IEvaluatorCallback callback, ILoggerFactory loggerFactory)
+        public Evaluator(IRepository repository, IEvaluatorCallback callback, ILoggerFactory loggerFactory, bool isAnalyticsEnabled)
         {
             this.repository = repository;
             this.callback = callback;
             this.logger = loggerFactory.CreateLogger<Evaluator>();
             this.loggerFactory = loggerFactory;
+            this.IsAnalyticsEnabled = isAnalyticsEnabled;
         }
         private Variation EvaluateVariation(string key, dto.Target target, FeatureConfigKind kind)
         {
@@ -55,7 +57,7 @@ namespace io.harness.cfsdk.client.api
             }
 
             Variation var = Evaluate(featureConfig, target);
-            if(var != null && callback != null)
+            if(IsAnalyticsEnabled && var != null && callback != null)
             {
                 this.callback.EvaluationProcessed(featureConfig, target, var);
             }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -74,9 +74,9 @@ namespace io.harness.cfsdk.client.api
         {
             var analyticsCache = new AnalyticsCache();
             var isPowerOfTwo = config.bufferSize > 0 && (config.bufferSize & (config.bufferSize - 1)) == 0;
-            if (isPowerOfTwo || config.bufferSize > 4096)
+            if (!isPowerOfTwo || config.bufferSize > 4096)
             {
-                logger.LogWarning("BufferSize must be a power of 2 and not exceed 4096, Defaulting to 2048");
+                logger.LogWarning("BufferSize Config option must be a power of 2 and not exceed 4096, Defaulting to 2048");
             }
             this.sdkReadyLatch.Reset(1);
             this.connector = connector;

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -79,7 +79,7 @@ namespace io.harness.cfsdk.client.api
             this.repository = new StorageRepository(config.Cache, config.Store, this, loggerFactory);
             this.polling = new PollingProcessor(connector, this.repository, config, this, loggerFactory);
             this.update = new UpdateProcessor(connector, this.repository, config, this, loggerFactory);
-            this.evaluator = new Evaluator(this.repository, this, loggerFactory);
+            this.evaluator = new Evaluator(this.repository, this, loggerFactory, config.analyticsEnabled);
             // Since 1.4.2, we enable the global target for evaluation metrics. 
             this.metric = new MetricsProcessor(config, analyticsCache, new AnalyticsPublisherService(connector, analyticsCache, loggerFactory), loggerFactory, true);
             Start();

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -73,11 +73,6 @@ namespace io.harness.cfsdk.client.api
         public void Initialize(IConnector connector, Config config)
         {
             var analyticsCache = new AnalyticsCache();
-            var isPowerOfTwo = config.bufferSize > 0 && (config.bufferSize & (config.bufferSize - 1)) == 0;
-            if (!isPowerOfTwo || config.bufferSize > 4096)
-            {
-                logger.LogWarning("BufferSize Config option must be a power of 2 and not exceed 4096, Defaulting to 2048");
-            }
             this.sdkReadyLatch.Reset(1);
             this.connector = connector;
             this.authService = new AuthService(connector, config, this, loggerFactory);

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -73,6 +73,11 @@ namespace io.harness.cfsdk.client.api
         public void Initialize(IConnector connector, Config config)
         {
             var analyticsCache = new AnalyticsCache();
+            var isPowerOfTwo = config.bufferSize > 0 && (config.bufferSize & (config.bufferSize - 1)) == 0;
+            if (isPowerOfTwo || config.bufferSize > 4096)
+            {
+                logger.LogWarning("BufferSize must be a power of 2 and not exceed 4096, Defaulting to 2048");
+            }
             this.sdkReadyLatch.Reset(1);
             this.connector = connector;
             this.authService = new AuthService(connector, config, this, loggerFactory);

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -54,16 +54,14 @@ namespace io.harness.cfsdk.client.api.analytics
         public void PushToCache(Target target, FeatureConfig featureConfig, Variation variation)
         {
             var cacheSize = analyticsCache.GetAllElements().Count;
-            var bufferSize = config.getBufferSize();
+            var bufferSize = config.bufferSize;
 
             if (cacheSize > bufferSize)
             {
                 logger.LogWarning(
-                    "Metric frequency map exceeded buffer size ({cacheSize} > {bufferSize}), force flushing", cacheSize,
+                    "Metric frequency map exceeded buffer size ({cacheSize} > {bufferSize}), not sending any further" +
+                    "metrics for interval. Increase metrics buffer using client config option if required. ", cacheSize,
                     bufferSize);
-
-                // If the map is starting to grow too much then push the metrics now and reset the counters
-                SendMetrics();
             }
             else
             {

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -16,6 +16,7 @@ namespace io.harness.cfsdk.client.api.analytics
         private Timer timer;
         
         private bool isGlobalTargetEnabled;
+        private bool warningLoggedForInterval = false;
 
         public MetricsProcessor(Config config, AnalyticsCache analyticsCache,
             AnalyticsPublisherService analyticsPublisherService, ILoggerFactory loggerFactory, bool globalTargetEnabled)
@@ -56,48 +57,73 @@ namespace io.harness.cfsdk.client.api.analytics
             var cacheSize = analyticsCache.GetAllElements().Count;
             var bufferSize = config.bufferSize;
 
-            if (cacheSize > bufferSize)
+            if (isGlobalTargetEnabled)
             {
-                logger.LogWarning(
-                    "Metric frequency map exceeded buffer size ({cacheSize} > {bufferSize}), not sending any further" +
-                    "metrics for interval. Increase metrics buffer using client config option if required. ", cacheSize,
-                    bufferSize);
+                var globalTarget = new Target(EvaluationAnalytics.GlobalTargetIdentifier,
+                    EvaluationAnalytics.GlobalTargetName, null);
+                PushToEvaluationAnalyticsCache(featureConfig, variation, globalTarget, cacheSize, bufferSize);
             }
             else
             {
-                if (isGlobalTargetEnabled)
-                {
-                    var globalTarget = new Target(EvaluationAnalytics.GlobalTargetIdentifier,
-                        EvaluationAnalytics.GlobalTargetName, null);
-                    PushToEvaluationAnalyticsCache(featureConfig, variation, globalTarget);
-                }
-                else
-                {
-                    PushToEvaluationAnalyticsCache(featureConfig, variation, target);
-                }
-
-                // Create target metrics 
-                PushToTargetAnalyticsCache(target);
-
+                PushToEvaluationAnalyticsCache(featureConfig, variation, target, cacheSize, bufferSize);
             }
+
+            // Create target metrics 
+            PushToTargetAnalyticsCache(target, cacheSize, bufferSize);
         }
 
-        private void PushToEvaluationAnalyticsCache(FeatureConfig featureConfig, Variation variation, Target target)
+        private void PushToEvaluationAnalyticsCache(FeatureConfig featureConfig, Variation variation, Target target,
+            int cacheSize, int bufferSize)
         {
             Analytics evaluationAnalytics = new EvaluationAnalytics(featureConfig, variation, target);
+
             var evaluationCount = analyticsCache.getIfPresent(evaluationAnalytics);
+
+            // Cache is full and this is new entry, so we should discard this eval
+            if (cacheSize > bufferSize && evaluationCount == 0)
+            {
+                LogMetricsIgnoredWarning(cacheSize, bufferSize);
+                return;
+            }
+            
+            // If cache isn't full, or if there is an existing matching key, add this one
             analyticsCache.Put(evaluationAnalytics, evaluationCount + 1);
         }
-        
-        private void PushToTargetAnalyticsCache(Target target)
+
+
+        private void PushToTargetAnalyticsCache(Target target, int cacheSize, int bufferSize)
         {
+            //  Cache is full, discard target
+            if (cacheSize > bufferSize)
+            {
+                LogMetricsIgnoredWarning(cacheSize, bufferSize);
+                return;
+            }
+
             Analytics targetAnalytics = new TargetAnalytics(target);
-            
+
             // We don't need to keep count of targets, so use a constant value, 1, for the count. 
             // Since 1.4.2, the analytics cache was refactored to separate out Evaluation and Target metrics, but the 
             // change did not go as far as to maintain two caches (due to effort involved), but differentiate them based on subclassing, so 
             // the counter used for target metrics isn't needed, but causes no issue. 
             analyticsCache.Put(targetAnalytics, 1);
+        }
+
+        private void LogMetricsIgnoredWarning(int cacheSize, int bufferSize)
+        {
+            // Only log this once per interval
+            if (warningLoggedForInterval)
+            {
+                return;
+            }
+            
+            logger.LogWarning(
+                "Metric frequency map exceeded buffer size ({cacheSize} > {bufferSize}), not sending any further" +
+                "metrics for interval. Increase metrics buffer using client config option if required. ",
+                cacheSize,
+                bufferSize);
+            
+            warningLoggedForInterval = true;
         }
 
         internal void Timer_Elapsed(object sender, ElapsedEventArgs e)
@@ -111,6 +137,7 @@ namespace io.harness.cfsdk.client.api.analytics
             try
             {
                 analyticsPublisherService.SendDataAndResetCache();
+                warningLoggedForInterval = false;
             }
             catch (CfClientException ex)
             {

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.4.2</Version>
+        <Version>1.4.3</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.4.2</PackageVersion>
-        <AssemblyVersion>1.4.2</AssemblyVersion>
+        <PackageVersion>1.4.3</PackageVersion>
+        <AssemblyVersion>1.4.3</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2023</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>

--- a/tests/ff-server-sdk-test/EvaluatorTest.cs
+++ b/tests/ff-server-sdk-test/EvaluatorTest.cs
@@ -56,7 +56,7 @@ namespace ff_server_sdk_test
             var listener = new EvaluatorListener();
             cache = new FeatureSegmentCache();
             repository = new StorageRepository(cache, null, null, loggerFactory);
-            evaluator = new Evaluator(repository, listener, loggerFactory);
+            evaluator = new Evaluator(repository, listener, loggerFactory, true);
         }
 
         private static void LoadSegments(List<Segment> segments)

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -237,34 +237,6 @@ namespace ff_server_sdk_test.api.analytics
         }
 
         [Test]
-        public void Should_force_push_metrics_and_clear_cache_when_analytics_cache_full()
-        {
-            // Arrange
-            var analyticsCacheMock = new AnalyticsCache();
-            var connectorMock = new Mock<IConnector>();
-
-            var bufferSize = 2;
-            var configMock = new Config("", "", false, 10, true, 1, bufferSize, 10, 10, 10, false, 10000);
-            var analyticsPublisherServiceMock =
-                new AnalyticsPublisherService(connectorMock.Object, analyticsCacheMock, new NullLoggerFactory());
-
-            var target = new Target();
-            var variation = new Variation();
-
-            var sut = new MetricsProcessor(configMock, analyticsCacheMock, analyticsPublisherServiceMock,
-                new NullLoggerFactory(), false);
-
-            // Act - set cachesize > buffer
-            sut.PushToCache(target, CreateFeatureConfig("feature1"), variation);
-            sut.PushToCache(target, CreateFeatureConfig("feature2"), variation);
-            sut.PushToCache(target, CreateFeatureConfig("feature3"), variation);
-
-            // Assert 
-            connectorMock.Verify(a => a.PostMetrics(It.IsAny<Metrics>()), Times.Once);
-            Assert.That(analyticsCacheMock.GetAllElements().Count, Is.EqualTo(0));
-        }
-
-        [Test]
         public void Should_Push_Targets_To_GlobalTargetSet_Using_MetricsProcessor()
         {
             var analyticsCache = new AnalyticsCache();
@@ -366,7 +338,7 @@ namespace ff_server_sdk_test.api.analytics
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
             var count = AnalyticsPublisherService.SeenTargets.Count;
-            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 41);
+            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 40);
         }
 
 


### PR DESCRIPTION
# Evaluation thread making network requests
Previously, when an evaluation, prior to storing the record to the cache it would flush and send metrics if the buffer size was exceeded. This is problematic for two reasons:
1. race condition because the metrics thread can also modify that cache. 
2. the evaluation thread should not be sending any network requests which can result in added latency.

# Fix
Instead of flushing and sending metrics if the buffer size is exceeded, we not stop recording metrics for the period of that interval, and log a warning.
This also adds a config option that users can set a max cache size of 4096 if required.

# Disabling metrics did not disable metrics completely
If metrics is disabled, the evaluation thread can still post metrics if it detected the buffer size was at capacity. 

# Fix
Return early, don't attempt to do any metrics related operations if metrics is disabled


# Testing for both
Both fixes are relatively simple and I have tested them using a sample .NET application.
