### PR TITLE
FFM-10837 Remove redundancy in the seen target process

### DIFF
--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -96,6 +96,13 @@ namespace io.harness.cfsdk.client.api.analytics
 
         private void PushToTargetAnalyticsCache(Target target)
         {
+
+            if (target.IsPrivate)
+            {
+                // Target is marked as private, so don't send it in analytics
+                return;
+            }
+            
             if (analyticsPublisherService.IsTargetSeen(target))
             {
                 // Target has already been processed in a previous interval, so ignore it.

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -118,6 +118,8 @@ namespace io.harness.cfsdk.client.api.analytics
             // change did not go as far as to maintain two caches (due to effort involved), but differentiate them based on subclassing, so 
             // the counter used for target metrics isn't needed, but causes no issue. 
             targetAnalyticsCache.Put(targetAnalytics, 1);
+
+            analyticsPublisherService.MarkTargetAsSeen(target);
         }
 
         private void LogMetricsIgnoredWarning(string cacheType, int cacheSize, int bufferSize)

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -119,12 +119,9 @@ namespace io.harness.cfsdk.client.api.analytics
             return SeenTargets.ContainsKey(target);
         }
         
-        public bool MarkTargetAsSeen(Target target)
+        public void MarkTargetAsSeen(Target target)
         {
-            // Attempt to mark the target as seen by adding it to the SeenTargets dictionary.
-            // The byte value associated with each target is not used, so it can be set to any arbitrary value.
-            // We use 0 here for simplicity. The key operation is whether the target can be added (i.e., has not been seen before).
-            return SeenTargets.TryAdd(target, 0);
+            SeenTargets.TryAdd(target, 0);
         }
 
 

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -17,9 +17,7 @@ namespace io.harness.cfsdk.client.api.analytics
         private static readonly string VariationIdentifierAttribute = "variationIdentifier";
         private static readonly string TargetAttribute = "target";
         internal static readonly ConcurrentDictionary<Target, byte> SeenTargets = new();
-        private static readonly ConcurrentDictionary<Target, byte> StagingSeenTargets = new();
         private static readonly string SdkType = "SDK_TYPE";
-        private static readonly string AnonymousTarget = "anonymous";
         private static readonly string Server = "server";
         private static readonly string SdkLanguage = "SDK_LANGUAGE";
         private static readonly string SdkVersion = "SDK_VERSION";
@@ -55,9 +53,7 @@ namespace io.harness.cfsdk.client.api.analytics
                         logger.LogDebug("Sending analytics data :{@a}", metrics);
                         connector.PostMetrics(metrics);
                     }
-
-                    foreach (var uniqueTarget in StagingSeenTargets.Keys) SeenTargets.TryAdd(uniqueTarget, 0);
-                    StagingSeenTargets.Clear();
+                    
                     logger.LogDebug("Successfully sent analytics data to the server");
                     evaluationAnalyticsCache.resetCache();
                     targetAnalyticsCache.resetCache();
@@ -94,7 +90,6 @@ namespace io.harness.cfsdk.client.api.analytics
                 SetMetricsAttributes(metricsData, VariationValueAttribute, evaluation.Variation.Value);
                 SetMetricsAttributes(metricsData, TargetAttribute, evaluation.Target.Identifier);
                 SetCommonSdkAttributes(metricsData);
-                StagingSeenTargets.TryAdd(evaluation.Target, 0);
                 metrics.MetricsData.Add(metricsData);
             }
 
@@ -102,7 +97,7 @@ namespace io.harness.cfsdk.client.api.analytics
             foreach (var targetAnalytic in targetsCache)
             {
                 var target = targetAnalytic.Key.Target;
-                if (target != null && !SeenTargets.ContainsKey(target) && !target.IsPrivate)
+                if (target != null && !target.IsPrivate)
                 {
                     var targetData = new TargetData
                     {
@@ -110,15 +105,6 @@ namespace io.harness.cfsdk.client.api.analytics
                         Name = target.Name,
                         Attributes = new List<KeyValue>()
                     };
-
-                    // Add target attributes, respecting private attributes
-                    foreach (var attribute in target.Attributes)
-                        if (target.PrivateAttributes == null || !target.PrivateAttributes.Contains(attribute.Key))
-                            targetData.Attributes.Add(new KeyValue
-                                { Key = attribute.Key, Value = attribute.Value });
-
-                    // Add to StagingSeenTargets for future reference
-                    StagingSeenTargets.TryAdd(target, 0);
 
                     metrics.TargetData.Add(targetData);
                 }
@@ -132,6 +118,15 @@ namespace io.harness.cfsdk.client.api.analytics
         {
             return SeenTargets.ContainsKey(target);
         }
+        
+        public bool MarkTargetAsSeen(Target target)
+        {
+            // Attempt to mark the target as seen by adding it to the SeenTargets dictionary.
+            // The byte value associated with each target is not used, so it can be set to any arbitrary value.
+            // We use 0 here for simplicity. The key operation is whether the target can be added (i.e., has not been seen before).
+            return SeenTargets.TryAdd(target, 0);
+        }
+
 
         private void SetCommonSdkAttributes(MetricsData metricsData)
         {

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -97,7 +97,7 @@ namespace io.harness.cfsdk.client.api.analytics
             foreach (var targetAnalytic in targetsCache)
             {
                 var target = targetAnalytic.Key.Target;
-                if (target != null && !target.IsPrivate)
+                if (target != null)
                 {
                     var targetData = new TargetData
                     {

--- a/client/dto/Target.cs
+++ b/client/dto/Target.cs
@@ -20,8 +20,33 @@ namespace io.harness.cfsdk.client.dto
         {
             attributes = new Dictionary<string, string>();
         }
+        
+        public Target(string identifier, string name, Dictionary<string, string> attributes)
+        {
+            if (attributes == null)
+            {
+                Attributes = new Dictionary<string, string>();
+            }
+            else
+            {
+                Attributes = attributes;
+            }
 
-        [Obsolete("isPrivate and privateAttributes will be removed in a future release use other constructor instead")]
+            Identifier = identifier;
+            Name = name;
+            IsPrivate = false;
+        }
+        
+        public Target(string identifier, string name, Dictionary<string, string> attributes, bool isPrivate)
+        {
+            this.attributes = attributes ?? new Dictionary<string, string>();
+            this.identifier = identifier;
+            this.name = name;
+            this.isPrivate = isPrivate;
+        }
+
+
+        [Obsolete("privateAttributes will be removed in a future release. Use Target(string identifier, string name, Dictionary<string, string> attributes, bool isPrivate) to mark the entire target as private.")]
         public Target(string identifier, string name, Dictionary<string, string> attributes, bool isPrivate, HashSet<string> privateAttributes)
         {
             if (attributes == null)
@@ -39,27 +64,9 @@ namespace io.harness.cfsdk.client.dto
             PrivateAttributes = privateAttributes;
         }
 
-        public Target(string identifier, string name, Dictionary<string, string> attributes)
-        {
-            if (attributes == null)
-            {
-                Attributes = new Dictionary<string, string>();
-            }
-            else
-            {
-                Attributes = attributes;
-            }
-
-            Identifier = identifier;
-            Name = name;
-            IsPrivate = false;
-        }
-
         public string Name { get => name; set => name = value; }
         public string Identifier { get => identifier; set => identifier = value; }
         public Dictionary<string, string> Attributes { get => attributes; set => attributes = value; }
-
-        [Obsolete("Private attributes will be removed in a future release")]
         public bool IsPrivate { get => isPrivate; set => isPrivate = value; }
 
         [Obsolete("Private attributes will be removed in a future release")]
@@ -149,7 +156,6 @@ namespace io.harness.cfsdk.client.dto
             return this;
         }
 
-        [Obsolete("Private attributes will be removed in a future release")]
         public TargetBuilder IsPrivate(bool isPrivate)
         {
             this.isPrivate = isPrivate;

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -24,6 +24,20 @@ CfClient.Instance.Initialize(apiKey, Config.Builder()
 | enableStream    | SetStreamEnabled(true)                            | Enable streaming mode.                                                                                                                           | true                                 |
 | enableAnalytics | SetAnalyticsEnabled(true)                         | Enable analytics.  Metrics data is posted every 60s                                                                                              | true                                 |
 
+# Anonymous Target
+
+If you do not want a `Target` to be sent to Harness servers, you can use the `isPrivate` field.
+
+```csharp
+Target target1 = Target.builder()
+                .Identifier("myIdentifier")
+                .Name("myName")
+                .IsPrivate(true)
+                .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
+                .build();
+```            
+
+
 ## Logging Configuration
 You can configure the logger using Serilog.
 Add Serilog to your project with the following commands

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.5.0</Version>
+        <Version>1.6.0</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.5.0</PackageVersion>
-        <AssemblyVersion>1.5.0</AssemblyVersion>
+        <PackageVersion>1.6.0</PackageVersion>
+        <AssemblyVersion>1.6.0</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2023</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>


### PR DESCRIPTION
# What
- Previously, we were maintaining two collections for managing seen targets. This is not needed is wasteful. 
    - Removes `StagingSeenTargets`
    - Now checks `SeenTargets` immediately after an evaluation has been made in `pushToCache`, to avoid storing a target if it has been seen.
    - This has a performance boost - we are now able to make 92K more evaluations per second. 

- No longer stores private targets in the cache. Previously they were stored and only disregarded at time of the push to the backend. 


# Testing
Unit tests still passing
Manual test of seen targets behaviour using prod 2 account