### PR TITLE
FFM-10943 Fix target attributes not being sent

### DIFF
--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -105,6 +105,11 @@ namespace io.harness.cfsdk.client.api.analytics
                         Name = target.Name,
                         Attributes = new List<KeyValue>()
                     };
+                    
+                    // Populate target attributes
+                    foreach (var attribute in target.Attributes)
+                            targetData.Attributes.Add(new KeyValue
+                                { Key = attribute.Key, Value = attribute.Value });
 
                     metrics.TargetData.Add(targetData);
                 }

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -16,11 +16,11 @@ namespace io.harness.cfsdk.client.api.analytics
         private static readonly string VariationValueAttribute = "featureValue";
         private static readonly string VariationIdentifierAttribute = "variationIdentifier";
         private static readonly string TargetAttribute = "target";
-        internal static readonly ConcurrentDictionary<Target, byte> SeenTargets = new();
         private static readonly string SdkType = "SDK_TYPE";
         private static readonly string Server = "server";
         private static readonly string SdkLanguage = "SDK_LANGUAGE";
         private static readonly string SdkVersion = "SDK_VERSION";
+        internal readonly ConcurrentDictionary<Target, byte> SeenTargets = new();
         private readonly IConnector connector;
         private readonly EvaluationAnalyticsCache evaluationAnalyticsCache;
         private readonly ILogger<AnalyticsPublisherService> logger;

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.6.0</Version>
+        <Version>1.6.1</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.6.0</PackageVersion>
-        <AssemblyVersion>1.6.0</AssemblyVersion>
+        <PackageVersion>1.6.1</PackageVersion>
+        <AssemblyVersion>1.6.1</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2023</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -84,8 +84,8 @@ namespace ff_server_sdk_test.api.analytics
 
 
             // Ensure the cache totals are correct
-            Assert.That(evaluationAnalyticsCacheMock.GetAllElements().Count, Is.EqualTo(1));
-            Assert.That(targetAnalyticsCacheMock.GetAllElements().Count, Is.EqualTo(1));
+            Assert.That(evaluationAnalyticsCacheMock.Count, Is.EqualTo(1));
+            Assert.That(targetAnalyticsCacheMock.Count, Is.EqualTo(1));
 
 
             // Correct count
@@ -281,7 +281,7 @@ namespace ff_server_sdk_test.api.analytics
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
 
-            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.ContainsKey(target1),
+            Assert.IsTrue(analyticsPublisherService.SeenTargets.ContainsKey(target1),
                 "Target should be pushed to GlobalTargetSet");
         }
 
@@ -352,8 +352,8 @@ namespace ff_server_sdk_test.api.analytics
 
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
-            var count = AnalyticsPublisherService.SeenTargets.Count;
-            Assert.IsTrue(AnalyticsPublisherService.SeenTargets.Count == 40);
+            var count = analyticsPublisherService.SeenTargets.Count;
+            Assert.IsTrue(analyticsPublisherService.SeenTargets.Count == 40);
         }
 
 


### PR DESCRIPTION
# What
- The `privateAttributes` check was removed in https://github.com/harness/ff-dotnet-server-sdk/pull/105 This unfortuntaely removed the attributes from being added in general to the target metrics payload, which has been fixed in this PR. 
- Makes `SeenTargets` an instance variable as this should be instance specific. 

# Testing
Manual - target and correct attributes appear in UI.