### PR TITLE
[FFM-11002] - Fix exception handling in auth success callback

### DIFF
--- a/client/api/AuthService.cs
+++ b/client/api/AuthService.cs
@@ -53,7 +53,15 @@ namespace io.harness.cfsdk.client.api
             try
             {
                 await connector.Authenticate();
-                callback.OnAuthenticationSuccess();
+                try
+                {
+                    callback.OnAuthenticationSuccess();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "OnAuthenticationSuccess callback threw an exception, this will be ignored: {Message}", ex.Message);
+                }
+
                 Stop();
                 logger.LogDebug("Stopping authentication service");
             }

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -68,7 +68,15 @@ namespace io.harness.cfsdk.client.api
             }
 
             logger.LogDebug("Populate cache for first time after authentication");
-            Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() }).Wait();
+
+            try
+            {
+                Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() }).Wait();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "First poll failed: {Reason}", ex.Message);
+            }
 
             logger.LogDebug("SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}", intervalMs);
             // start timer which will initiate periodic reading of flags and segments
@@ -97,7 +105,7 @@ namespace io.harness.cfsdk.client.api
                 }
 
             }
-            catch (CfClientException ex)
+            catch (Exception ex)
             {
                 logger.LogError(ex,"Exception was raised when fetching flags data with the message: {reason}", ex.Message);
                 throw;
@@ -115,8 +123,10 @@ namespace io.harness.cfsdk.client.api
                 {
                     repository.SetSegment(item.Identifier, item);
                 }
+
+                logger.LogDebug("Loaded {SegmentRuleCount}", segments.Count());
             }
-            catch (CfClientException ex)
+            catch (Exception ex)
             {
                 logger.LogError(ex, "Exception was raised when fetching segments data with the message: {reason}", ex.Message);
                 throw;

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -44,7 +44,6 @@ namespace io.harness.cfsdk.client.api
         private readonly IRepository repository;
         private readonly IPollCallback callback;
         private readonly Config config;
-        private readonly SemaphoreSlim readyEvent;
         private Timer pollTimer;
         private bool isInitialized = false;
 
@@ -141,13 +140,12 @@ namespace io.harness.cfsdk.client.api
 
                 if (isInitialized) return;
                 isInitialized = true;
-                callback.OnPollerReady();
-                readyEvent.Release();
+                callback?.OnPollerReady();
             }
             catch(Exception ex)
             {
                 logger.LogWarning(ex,"Polling failed with error: {reason}. Will retry in {pollIntervalInSeconds}", ex.Message, config.pollIntervalInSeconds);
-                callback.OnPollError(ex.Message);
+                callback?.OnPollError(ex.Message);
             }
         }
     }

--- a/examples/tls-example/Program.cs
+++ b/examples/tls-example/Program.cs
@@ -1,6 +1,7 @@
 
 using System.Security.Cryptography.X509Certificates;
 using io.harness.cfsdk.client.api;
+using io.harness.cfsdk.client.dto;
 using Serilog;
 using Serilog.Extensions.Logging;
 
@@ -38,9 +39,14 @@ namespace io.harness.tls_example
 
             client.WaitForInitialization();
 
+            Target target = Target.builder()
+                .Name("DotNET SDK TLS")
+                .Identifier("dotnetsdktls")
+                .build();
+
             while (true)
             {
-                var resultBool = client.boolVariation(flagName, null, false);
+                var resultBool = client.boolVariation(flagName, target, false);
                 Console.WriteLine($"Flag '{flagName}' = " + resultBool);
                 Thread.Sleep(2 * 1000);
             }

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,12 +8,12 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.6.1</Version>
+        <Version>1.6.2</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.6.1</PackageVersion>
-        <AssemblyVersion>1.6.1</AssemblyVersion>
+        <PackageVersion>1.6.2</PackageVersion>
+        <AssemblyVersion>1.6.2</AssemblyVersion>
         <Authors>support@harness.io</Authors>
-        <Copyright>Copyright © 2023</Copyright>
+        <Copyright>Copyright © 2024</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
         <PackageLicenseUrl>https://github.com/drone/ff-dotnet-server-sdk/blob/main/LICENSE</PackageLicenseUrl>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
[FFM-11002] - Fix exception handling in auth success callback

**What**
- Avoid allowing exceptions thrown inside the auth success callback to trickle up to the auth service.
- On first poll catch any exceptions to allow poller to be started.

**Why**
If auth success callback threw an error the SDK would attempt to reauth even though it has authenticated ok previously. Also if there is a network error (or any other exception) thrown inside PollingProcessor's start() method then the poller will not be started. Failed polls should be treated as transient (e.g. network) and the next poll will allow the SDK to self heal.

**Testing**
Manual + testgrid

[FFM-11002]: https://harness.atlassian.net/browse/FFM-11002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ