### PR TITLE
FFM-11022 Evaluation class refactor

### DIFF
--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -276,16 +276,7 @@ namespace io.harness.cfsdk.client.api
 
             return null;
         }
-
-
-        private string EvaluateDistribution(FeatureConfig featureConfig, Target target)
-        {
-            if (featureConfig.Rules == null || target == null) return null;
-
-            var distributionProcessor = new DistributionProcessor(featureConfig.DefaultServe, loggerFactory);
-            return distributionProcessor.loadKeyName(target);
-        }
-
+        
         private bool IsTargetIncludedOrExcludedInSegment(List<string> segmentList, Target target) 
         {
             foreach (var segmentIdentifier in segmentList)
@@ -331,8 +322,8 @@ namespace io.harness.cfsdk.client.api
                 {
                     if (logger.IsEnabled(LogLevel.Debug))
                         logger.LogDebug(
-                            "Group condition rule matched: Target({TargetName}) Group({SegmentName})",
-                            target.ToString(), ToStringHelper.SegmentToString(segment));
+                            "Group condition rule matched: Condition({Condition}) Target({TargetName}) Group({SegmentName})",
+                            ToStringHelper.ClauseToString(firstSuccess), target.ToString(), ToStringHelper.SegmentToString(segment));
                     return true;
                 }
             }

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -259,7 +259,7 @@ namespace io.harness.cfsdk.client.api
 
             // Log if no applicable rule was found
             if (logger.IsEnabled(LogLevel.Debug))
-                logger.LogDebug("No applicable rule found for Target({Target}) in FeatureConfig {FeatureConfig}",
+                logger.LogDebug("No applicable rule found for Target({Target})  Flag({FeatureConfig})",
                     target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
 
             return null;
@@ -285,7 +285,7 @@ namespace io.harness.cfsdk.client.api
                 }
                 
                 logger.LogDebug("Evaluating group rule: Group({Segment} Target({Target}) )",
-                    target.ToString(), ToStringHelper.SegmentToString(segment));
+                    ToStringHelper.SegmentToString(segment), target.ToString() );
 
                 // check exclude list
                 if (segment.Excluded != null && segment.Excluded.Any(t => t.Identifier.Equals(target.Identifier)))

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -136,53 +136,6 @@ namespace io.harness.cfsdk.client.api
             return true;
         }
 
-        // private Variation Evaluate(FeatureConfig featureConfig, Target target)
-        // {
-        //     // TODO - this method needs cleaned up to avoid variable mutation. Too many mutations of the single variable. For now, it works, 
-        //     // but clean up in next release to make it more readable/maintainable.
-        //     logger.LogDebug("Evaluating: Flag({Flag}) Target({Target})",
-        //         ToStringHelper.FeatureConfigToString(featureConfig), target.ToString());
-        //     var variation = featureConfig.OffVariation;
-        //     if (featureConfig.State == FeatureState.On)
-        //     {
-        //         variation = null;
-        //         if (featureConfig.VariationToTargetMap != null)
-        //         {
-        //             variation = EvaluateVariationMap(target, featureConfig.VariationToTargetMap);
-        //             if (variation != null)
-        //                 logger.LogDebug("Specific targeting matched: Target({Target}) Flag({Flag})",
-        //                     target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-        //         }
-        //
-        //         if (variation == null) variation = EvaluateRules(featureConfig, target);
-        //         if (variation == null)
-        //         {
-        //             variation = EvaluateDistribution(featureConfig, target);
-        //             if (variation != null)
-        //                 logger.LogDebug("Percentage rollout matched: Target({Target}) Flag({Flag})",
-        //                     target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-        //         }
-        //
-        //         if (variation == null)
-        //         {
-        //             variation = featureConfig.DefaultServe.Variation;
-        //             if (variation != null)
-        //                 logger.LogDebug("Default on rule matched: Target({Target}) Flag({Flag})",
-        //                     target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-        //         }
-        //     }
-        //     else
-        //     {
-        //         logger.LogDebug("Flag is off:  Flag({Flag})",
-        //             ToStringHelper.FeatureConfigToString(featureConfig));
-        //     }
-        //
-        //     if (variation != null && featureConfig.Variations != null)
-        //         return featureConfig.Variations.FirstOrDefault(var => var.Identifier.Equals(variation));
-        //
-        //     return null;
-        // }
-
         private Variation Evaluate(FeatureConfig featureConfig, Target target)
         {
             if (logger.IsEnabled(LogLevel.Debug))

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -191,7 +191,7 @@ namespace io.harness.cfsdk.client.api
             if (featureConfig.State == FeatureState.Off)
             {
                 logger.LogDebug("Flag is off: Flag({Flag})", ToStringHelper.FeatureConfigToString(featureConfig));
-                return GetVariation(featureConfig, featureConfig.OffVariation);
+                return GetVariation(featureConfig.Variations, featureConfig.OffVariation);
             }
 
             // Check for specific targeting match
@@ -200,12 +200,12 @@ namespace io.harness.cfsdk.client.api
             {
                 logger.LogDebug("Specific targeting matched: Target({Target}) Flag({Flag})",
                     target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-                return GetVariation(featureConfig, specificTargetingVariation);
+                return GetVariation(featureConfig.Variations, specificTargetingVariation);
             }
 
             // Evaluate rules
             var rulesVariation = EvaluateRules(featureConfig, target);
-            if (rulesVariation != null) return GetVariation(featureConfig, rulesVariation);
+            if (rulesVariation != null) return GetVariation(featureConfig.Variations, rulesVariation);
 
             // TODO don't think this is needed, as we evaluate distribution in EvaluateRules
             // Evaluate distribution
@@ -214,7 +214,7 @@ namespace io.harness.cfsdk.client.api
             {
                 logger.LogDebug("Percentage rollout matched: Target({Target}) Flag({Flag})",
                     target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-                return GetVariation(featureConfig, distributionVariation);
+                return GetVariation(featureConfig.Variations, distributionVariation);
             }
 
             // Use default serve variation
@@ -228,12 +228,12 @@ namespace io.harness.cfsdk.client.api
 
             logger.LogDebug("Default on rule matched: Target({Target}) Flag({Flag})",
                 target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-            return GetVariation(featureConfig, defaultVariation);
+            return GetVariation(featureConfig.Variations, defaultVariation);
         }
 
-        private Variation GetVariation(FeatureConfig featureConfig, string variationIdentifier)
+        private Variation GetVariation(ICollection<Variation> variations, string variationIdentifier)
         {
-            return featureConfig.Variations?.FirstOrDefault(var => var.Identifier.Equals(variationIdentifier));
+            return variations.FirstOrDefault(var => var.Identifier.Equals(variationIdentifier));
         }
 
         private string EvaluateVariationMap(Target target, ICollection<VariationMap> variationMaps)

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -287,7 +287,7 @@ namespace io.harness.cfsdk.client.api
                     throw new InvalidCacheStateException(
                         $"Segment with identifier {segmentIdentifier} could not be found in the cache. This might indicate a cache inconsistency or missing data.");
 
-                logger.LogDebug("Evaluating group rule: Group({Segment} Target({Target}) )",
+                logger.LogDebug("Evaluating group rule: Group({Segment} Target({Target}))",
                     ToStringHelper.SegmentToString(segment), target.ToString());
 
                 // check exclude list
@@ -309,18 +309,23 @@ namespace io.harness.cfsdk.client.api
                     return true;
                 }
 
-                // if we have rules, at least one should pass
-                if (segment.Rules != null)
+                // Check custom rules
+                if (segment.Rules == null)
                 {
-                    var firstSuccess = segment.Rules.FirstOrDefault(r => EvaluateClause(r, target));
-                    if (firstSuccess != null)
-                    {
-                        if (logger.IsEnabled(LogLevel.Debug))
-                            logger.LogDebug(
-                                "Group condition rule matched: Target({TargetName}) Group({SegmentName})",
-                                target.ToString(), ToStringHelper.SegmentToString(segment));
-                        return true;
-                    }
+                    if (logger.IsEnabled(LogLevel.Debug))
+                        logger.LogDebug("No group rules found in group: Group({SegmentName})",
+                            ToStringHelper.SegmentToString(segment));
+                    return false;
+                }
+
+                var firstSuccess = segment.Rules.FirstOrDefault(r => EvaluateClause(r, target));
+                if (firstSuccess != null)
+                {
+                    if (logger.IsEnabled(LogLevel.Debug))
+                        logger.LogDebug(
+                            "Group condition rule matched: Target({TargetName}) Group({SegmentName})",
+                            target.ToString(), ToStringHelper.SegmentToString(segment));
+                    return true;
                 }
             }
 

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -191,7 +191,7 @@ namespace io.harness.cfsdk.client.api
             if (featureConfig.State == FeatureState.Off)
             {
                 logger.LogDebug("Flag is off: Flag({Flag})", ToStringHelper.FeatureConfigToString(featureConfig));
-                ReturnVariation(featureConfig, featureConfig.OffVariation);
+                return GetVariation(featureConfig, featureConfig.OffVariation);
             }
 
             // Check for specific targeting match
@@ -200,20 +200,21 @@ namespace io.harness.cfsdk.client.api
             {
                 logger.LogDebug("Specific targeting matched: Target({Target}) Flag({Flag})",
                     target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-                return ReturnVariation(featureConfig, specificTargetingVariation);
+                return GetVariation(featureConfig, specificTargetingVariation);
             }
 
             // Evaluate rules
             var rulesVariation = EvaluateRules(featureConfig, target);
-            if (rulesVariation != null) return ReturnVariation(featureConfig, rulesVariation);
+            if (rulesVariation != null) return GetVariation(featureConfig, rulesVariation);
 
+            // TODO don't think this is needed, as we evaluate distribution in EvaluateRules
             // Evaluate distribution
             var distributionVariation = EvaluateDistribution(featureConfig, target);
             if (distributionVariation != null)
             {
                 logger.LogDebug("Percentage rollout matched: Target({Target}) Flag({Flag})",
                     target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-                return ReturnVariation(featureConfig, distributionVariation);
+                return GetVariation(featureConfig, distributionVariation);
             }
 
             // Use default serve variation
@@ -227,10 +228,10 @@ namespace io.harness.cfsdk.client.api
 
             logger.LogDebug("Default on rule matched: Target({Target}) Flag({Flag})",
                 target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-            return ReturnVariation(featureConfig, defaultVariation);
+            return GetVariation(featureConfig, defaultVariation);
         }
 
-        private Variation ReturnVariation(FeatureConfig featureConfig, string variationIdentifier)
+        private Variation GetVariation(FeatureConfig featureConfig, string variationIdentifier)
         {
             return featureConfig.Variations?.FirstOrDefault(var => var.Identifier.Equals(variationIdentifier));
         }

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -204,9 +204,17 @@ namespace io.harness.cfsdk.client.api
                 if (variationMap.Targets != null && variationMap.Targets.ToList()
                         .Any(t => t != null && t.Identifier.Equals(target.Identifier))) return variationMap.Variation;
                 // Legacy: the variation to target map no longer contains TargetSegments. These are stored in group rules.
-                if (variationMap.TargetSegments != null &&
-                    IsTargetIncludedOrExcludedInSegment(variationMap.TargetSegments.ToList(), target))
-                    return variationMap.Variation;
+                try
+                {
+                    if (variationMap.TargetSegments != null &&
+                        IsTargetIncludedOrExcludedInSegment(variationMap.TargetSegments.ToList(), target))
+                        return variationMap.Variation;
+                }
+                catch (InvalidCacheStateException ex)
+                {
+                    logger.LogError(ex, "Invalid cache state detected while evaluating group rule");
+                }
+
             }
 
             return null;
@@ -278,7 +286,7 @@ namespace io.harness.cfsdk.client.api
             return distributionProcessor.loadKeyName(target);
         }
 
-        private bool IsTargetIncludedOrExcludedInSegment(List<string> segmentList, Target target)
+        private bool IsTargetIncludedOrExcludedInSegment(List<string> segmentList, Target target) 
         {
             foreach (var segmentIdentifier in segmentList)
             {

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -225,7 +225,7 @@ namespace io.harness.cfsdk.client.api
             {
                 logger.LogWarning("Default serve variation not found: Flag({Flag})",
                     ToStringHelper.FeatureConfigToString(featureConfig));
-                return null; 
+                return null;
             }
 
             logger.LogDebug("Default on rule matched: Target({Target}) Flag({Flag})",
@@ -268,12 +268,9 @@ namespace io.harness.cfsdk.client.api
                         servingRule.RuleId, ToStringHelper.FeatureConfigToString(featureConfig));
                     return null;
                 }
-                
+
                 // Proceed if any clause evaluation fails
-                if (servingRule.Clauses.Any(c => !EvaluateClause(c, target)))
-                {
-                    continue; 
-                }
+                if (servingRule.Clauses.Any(c => !EvaluateClause(c, target))) continue;
 
                 // Invalid state: Log if Serve is null
                 if (servingRule.Serve == null)
@@ -313,35 +310,6 @@ namespace io.harness.cfsdk.client.api
 
             return null;
         }
-
-
-        // private string EvaluateRules(FeatureConfig featureConfig, Target target)
-        // {
-        //     if (featureConfig.Rules == null || target == null) return null;
-        //
-        //     foreach (var servingRule in featureConfig.Rules.ToList().OrderBy(sr => sr.Priority))
-        //     {
-        //         if (servingRule.Clauses != null &&
-        //             servingRule.Clauses.ToList().Any(c => EvaluateClause(c, target) == false)) continue;
-        //
-        //         if (servingRule.Serve != null)
-        //         {
-        //             if (servingRule.Serve.Distribution != null)
-        //             {
-        //                 if (logger.IsEnabled(LogLevel.Debug))
-        //                     logger.LogDebug(
-        //                         "Percentage rollout applies, evaluating distribution: Target({Target}) Flag({Flag})",
-        //                         target.ToString(), ToStringHelper.FeatureConfigToString(featureConfig));
-        //                 var distributionProcessor = new DistributionProcessor(servingRule.Serve, loggerFactory);
-        //                 return distributionProcessor.loadKeyName(target);
-        //             }
-        //
-        //             if (servingRule.Serve.Variation != null) return servingRule.Serve.Variation;
-        //         }
-        //     }
-        //
-        //     return null;
-        // }
 
 
         private string EvaluateDistribution(FeatureConfig featureConfig, Target target)

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -46,79 +46,40 @@ namespace io.harness.cfsdk.client.api
 
         public bool BoolVariation(string key, Target target, bool defaultValue)
         {
-            try
-            {
-                var variation = EvaluateVariation(key, target, FeatureConfigKind.Boolean);
-                bool res;
-                if (variation != null && bool.TryParse(variation.Value, out res)) return res;
+            var variation = EvaluateVariation(key, target, FeatureConfigKind.Boolean);
+            bool res;
+            if (variation != null && bool.TryParse(variation.Value, out res)) return res;
 
-                LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
-                return defaultValue;
-            }
-            catch (InvalidCacheStateException ex)
-            {
-                logger.LogError(ex, "Invalid cache state detected when evaluating boolean variation for flag {Key}", key);
-                LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
-                return defaultValue;
-            }
+            LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
+            return defaultValue;
         }
 
         public JObject JsonVariation(string key, Target target, JObject defaultValue)
         {
-            try
-            {
-                var variation = EvaluateVariation(key, target, FeatureConfigKind.Json);
-                if (variation != null) return JObject.Parse(variation.Value);
+            var variation = EvaluateVariation(key, target, FeatureConfigKind.Json);
+            if (variation != null) return JObject.Parse(variation.Value);
 
-                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
-                return defaultValue;
-            }
-            catch (InvalidCacheStateException ex)
-            {
-                logger.LogError(ex, "Invalid cache state detected when evaluating json variation for flag {Key}",
-                    key);
-                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
-                return defaultValue;
-            }
+            LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
+            return defaultValue;
         }
 
         public double NumberVariation(string key, Target target, double defaultValue)
         {
-            try
-            {
-                var variation = EvaluateVariation(key, target, FeatureConfigKind.Int);
-                double res;
-                if (variation != null && double.TryParse(variation.Value, out res)) return res;
+            var variation = EvaluateVariation(key, target, FeatureConfigKind.Int);
+            double res;
+            if (variation != null && double.TryParse(variation.Value, out res)) return res;
 
-                LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue.ToString());
-                return defaultValue;
-            }
-            catch (InvalidCacheStateException ex)
-            {
-                logger.LogError(ex, "Invalid cache state detected when evaluating number variation for flag {Key}",
-                    key);
-                LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
-                return defaultValue;
-            }
+            LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue.ToString());
+            return defaultValue;
         }
 
         public string StringVariation(string key, Target target, string defaultValue)
         {
-            try
-            {
-                var variation = EvaluateVariation(key, target, FeatureConfigKind.String);
-                if (variation != null) return variation.Value;
+            var variation = EvaluateVariation(key, target, FeatureConfigKind.String);
+            if (variation != null) return variation.Value;
 
-                LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
-                return defaultValue;
-            }
-            catch (InvalidCacheStateException ex)
-            {
-                logger.LogError(ex, "Invalid cache state detected when evaluating string variation for flag {Key}",
-                    key);
-                LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
-                return defaultValue;
-            }
+            LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
+            return defaultValue;
         }
 
         private Variation EvaluateVariation(string key, Target target, FeatureConfigKind kind)

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -107,7 +107,7 @@ namespace io.harness.cfsdk.client.api
         {
             if (logger.IsEnabled(LogLevel.Warning))
                 logger.LogWarning(
-                    "SDKCODE(eval:6001): Failed to evaluate {kind} variation for {targetId}, flag {featureId} and the default variation {defaultValue} is being returned",
+                    "SDKCODE(eval:6001): Failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId} and the default variation {DefaultValue} is being returned",
                     kind, target?.Identifier ?? "null target", featureKey, defaultValue);
         }
 
@@ -363,7 +363,7 @@ namespace io.harness.cfsdk.client.api
                     if (segment.Excluded != null && segment.Excluded.Any(t => t.Identifier.Equals(target.Identifier)))
                     {
                         if (logger.IsEnabled(LogLevel.Debug))
-                            logger.LogDebug("Group excluded rule matched: Target({targetName}) Group({segmentName})",
+                            logger.LogDebug("Group excluded rule matched: Target({TargetName}) Group({SegmentName})",
                                 target.ToString(), ToStringHelper.SegmentToString(segment));
                         return false;
                     }
@@ -372,7 +372,7 @@ namespace io.harness.cfsdk.client.api
                     if (segment.Included != null && segment.Included.Any(t => t.Identifier.Equals(target.Identifier)))
                     {
                         if (logger.IsEnabled(LogLevel.Debug))
-                            logger.LogDebug("Group included rule matched: Target({targetName}) Group({segmentName})",
+                            logger.LogDebug("Group included rule matched: Target({TargetName}) Group({SegmentName})",
                                 target.ToString(), ToStringHelper.SegmentToString(segment));
 
                         return true;
@@ -386,7 +386,7 @@ namespace io.harness.cfsdk.client.api
                         {
                             if (logger.IsEnabled(LogLevel.Debug))
                                 logger.LogDebug(
-                                    "Group condition rule matched: Target({targetName}) Group({segmentName})",
+                                    "Group condition rule matched: Target({TargetName}) Group({SegmentName})",
                                     target.ToString(), ToStringHelper.SegmentToString(segment));
                             return true;
                         }
@@ -443,7 +443,7 @@ namespace io.harness.cfsdk.client.api
                 case "name":
                     return target.Name;
                 default:
-                    if ((target.Attributes != null) & target.Attributes.ContainsKey(attribute))
+                    if (target.Attributes != null && target.Attributes.ContainsKey(attribute))
                         return target.Attributes[attribute];
                     return null;
             }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -224,6 +224,7 @@ namespace io.harness.cfsdk.client.api
                 logger.LogError(ex, "Invalid cache state detected when evaluating boolean variation for flag {Key}",
                     key);
                 LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
+                polling.TriggerProcessSegments();
                 return defaultValue;
             }
         }
@@ -239,6 +240,7 @@ namespace io.harness.cfsdk.client.api
                 logger.LogError(ex, "Invalid cache state detected when evaluating string variation for flag {Key}",
                     key);
                 LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
+                polling.TriggerProcessSegments();
                 return defaultValue;
             }
         }
@@ -254,6 +256,7 @@ namespace io.harness.cfsdk.client.api
                 logger.LogError(ex, "Invalid cache state detected when evaluating number variation for flag {Key}",
                     key);
                 LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
+                polling.TriggerProcessSegments();
                 return defaultValue;
             }
         }
@@ -269,6 +272,7 @@ namespace io.harness.cfsdk.client.api
                 logger.LogError(ex, "Invalid cache state detected when evaluating json variation for flag {Key}",
                     key);
                 LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
+                polling.TriggerProcessSegments();
                 return defaultValue;
             }
         }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Target = io.harness.cfsdk.client.dto.Target;
 
 namespace io.harness.cfsdk.client.api
 {
@@ -214,19 +215,62 @@ namespace io.harness.cfsdk.client.api
 
         public bool BoolVariation(string key, dto.Target target, bool defaultValue)
         {
-            return evaluator.BoolVariation(key, target, defaultValue);
+            try
+            {
+                return evaluator.BoolVariation(key, target, defaultValue);
+            }
+            catch (InvalidCacheStateException ex)
+            {
+                logger.LogError(ex, "Invalid cache state detected when evaluating boolean variation for flag {Key}",
+                    key);
+                LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
+                return defaultValue;
+            }
         }
+
         public string StringVariation(string key, dto.Target target, string defaultValue)
         {
-            return evaluator.StringVariation(key, target, defaultValue);
+            try
+            {
+                return evaluator.StringVariation(key, target, defaultValue);
+            }
+            catch (InvalidCacheStateException ex)
+            {
+                logger.LogError(ex, "Invalid cache state detected when evaluating string variation for flag {Key}",
+                    key);
+                LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
+                return defaultValue;
+            }
         }
-        public double NumberVariation(string key, dto.Target target, double defaultValue)
+
+        public double NumberVariation(string key, Target target, double defaultValue)
         {
-            return evaluator.NumberVariation(key, target, defaultValue);
+            try
+            {
+                return evaluator.NumberVariation(key, target, defaultValue);
+            }
+            catch (InvalidCacheStateException ex)
+            {
+                logger.LogError(ex, "Invalid cache state detected when evaluating number variation for flag {Key}",
+                    key);
+                LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
+                return defaultValue;
+            }
         }
-        public JObject JsonVariation(string key, dto.Target target, JObject defaultValue)
+
+        public JObject JsonVariation(string key, Target target, JObject defaultValue)
         {
-            return evaluator.JsonVariation(key, target, defaultValue);
+            try
+            {
+                return evaluator.JsonVariation(key, target, defaultValue);
+            }
+            catch (InvalidCacheStateException ex)
+            {
+                logger.LogError(ex, "Invalid cache state detected when evaluating json variation for flag {Key}",
+                    key);
+                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
+                return defaultValue;
+            }
         }
 
         public void Close()
@@ -247,6 +291,15 @@ namespace io.harness.cfsdk.client.api
         public void EvaluationProcessed(FeatureConfig featureConfig, dto.Target target, Variation variation)
         {
             this.metric.PushToCache(target, featureConfig, variation);
+        }
+        
+        public void LogEvaluationFailureError(FeatureConfigKind kind, string featureKey, dto.Target target,
+            string defaultValue)
+        {
+            if (logger.IsEnabled(LogLevel.Warning))
+                logger.LogWarning(
+                    "SDKCODE(eval:6001): Failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId} and the default variation {DefaultValue} is being returned",
+                    kind, target?.Identifier ?? "null target", featureKey, defaultValue);
         }
     }
 }

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -29,6 +29,8 @@ namespace io.harness.cfsdk.client.api
         /// Start periodic pooling
         /// </summary>
         void Start();
+
+        void TriggerProcessSegments();
     }
 
     /// <summary>
@@ -131,6 +133,21 @@ namespace io.harness.cfsdk.client.api
                 throw;
             }
         }
+        
+        public void TriggerProcessSegments()
+        {
+            Task.Run(async () => await ProcessSegments())
+                .ContinueWith(task =>
+                {
+                    if (task.Exception != null)
+                    {
+                        // Handle exceptions from ProcessSegments
+                        logger.LogError(task.Exception, "Error occurred in TriggerProcessSegments");
+                    }
+                });
+        }
+
+        
         private async void OnTimedEventAsync(object source)
         {
             try

--- a/client/api/ToStringHelper.cs
+++ b/client/api/ToStringHelper.cs
@@ -42,8 +42,8 @@ namespace io.harness.cfsdk.client.api
                 ? string.Join(", ", featureConfig.Prerequisites.Select(p => p.Feature))
                 : "None";
 
-            var variationMapsStr = featureConfig.VariationToTargetMap != null
-                ? string.Join(", ", featureConfig.VariationToTargetMap.Select(vm => vm.Variation))
+            var variationMapsStr = featureConfig.VariationToTargetMap != null && featureConfig.VariationToTargetMap.Any()
+                ? string.Join(", ", featureConfig.VariationToTargetMap.Select(VariationMapToString))
                 : "None";
 
             return
@@ -63,6 +63,25 @@ namespace io.harness.cfsdk.client.api
 
             return
                 $"RuleId: {servingRule.RuleId}, Priority: {servingRule.Priority}, Clauses: [{clausesStr}], Serve: [{serveStr}]";
+        }
+
+        public static string VariationMapToString(VariationMap variationMap)
+        {
+            var targetsStr = variationMap.Targets != null && variationMap.Targets.Any()
+                ? string.Join(", ", variationMap.Targets.Select(t => TargetMapToString(t)))
+                : "None";
+
+            var targetSegmentsStr = variationMap.TargetSegments != null && variationMap.TargetSegments.Any()
+                ? string.Join(", ", variationMap.TargetSegments)
+                : "None";
+
+            return
+                $"Variation: {variationMap.Variation}, Targets: [{targetsStr}], TargetSegments: [{targetSegmentsStr}]";
+        }
+
+        public static string TargetMapToString(TargetMap targetMap)
+        {
+            return $"Identifier: {targetMap.Identifier}";
         }
     }
 }

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.6.3</Version>
+        <Version>1.6.4</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.6.3</PackageVersion>
-        <AssemblyVersion>1.6.3</AssemblyVersion>
+        <PackageVersion>1.6.4</PackageVersion>
+        <AssemblyVersion>1.6.4</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>


### PR DESCRIPTION
# What
- Refactors `Evaluate` method to immutability 
- Logs `null` flag/group objects which would indicate invalid cache state
- If the group can't be found, throws new `InvalidCacheState` ex which the variation methods catch, and returns the default variation.  The `InnerClient` variation methods then trigger a group cache refresh which is non-blocking.
- Much more additional logging of evaluation paths to aid in debugging

# Testing
- Ran through TestGrid evaluation suite
- Manual with prod 2 account