### PR TITLE
FFM-11022 Flag/Group cache recovery

### DIFF
--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -43,7 +43,6 @@ namespace io.harness.cfsdk.client.api
             this.debug = debug;
             this.metricsServiceAcceptableDuration = metricsServiceAcceptableDuration;
             this.cacheRecoveryTimeoutInMs = cacheRecoveryTimeoutInMs;
-
         }
 
         public Config()

--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -22,10 +22,13 @@ namespace io.harness.cfsdk.client.api
         internal bool streamEnabled = true;
         internal int evaluationMetricsMaxSize = 10000;
         internal int targetMetricsMaxSize = 100000;
+        internal int cacheRecoveryTimeoutInMs = 5000; 
+
+
 
         public Config(string configUrl, string eventUrl, bool streamEnabled, int pollIntervalInSeconds,
             bool analyticsEnabled, int frequency, int targetMetricsMaxSize, int connectionTimeout, int readTimeout,
-            int writeTimeout, bool debug, long metricsServiceAcceptableDuration)
+            int writeTimeout, bool debug, long metricsServiceAcceptableDuration, int cacheRecoveryTimeoutInMs)
         {
             this.configUrl = configUrl;
             this.eventUrl = eventUrl;
@@ -39,6 +42,8 @@ namespace io.harness.cfsdk.client.api
             this.writeTimeout = writeTimeout;
             this.debug = debug;
             this.metricsServiceAcceptableDuration = metricsServiceAcceptableDuration;
+            this.cacheRecoveryTimeoutInMs = cacheRecoveryTimeoutInMs;
+
         }
 
         public Config()
@@ -64,6 +69,7 @@ namespace io.harness.cfsdk.client.api
 
         public int TargetMetricsMaxSize => targetMetricsMaxSize;
         public int EvaluationMetricsMaxSize => evaluationMetricsMaxSize;
+        public int CacheRecoveryTimeoutInMs => cacheRecoveryTimeoutInMs;
 
 
         /**
@@ -187,6 +193,12 @@ namespace io.harness.cfsdk.client.api
         public ConfigBuilder debug(bool debug)
         {
             configtobuild.debug = debug;
+            return this;
+        }
+        
+        public ConfigBuilder SetCacheRecoveryTimeout(int timeoutMilliseconds)
+        {
+            configtobuild.cacheRecoveryTimeoutInMs = timeoutMilliseconds;
             return this;
         }
 

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -112,7 +112,7 @@ namespace io.harness.cfsdk.client.api
             if (featureConfig.Kind != kind)
             {
                 logger.LogWarning(
-                    "Requested variation {Kind} does not match flag {Key} which is of type {featureConfigKind} in cache",
+                    "Requested variation {Kind} does not match flag {Key} which is of type {featureConfigKind}",
                     kind,  key, featureConfig.Kind);
                 return null;
             }

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -33,7 +33,7 @@ namespace io.harness.cfsdk.client.api
         private readonly ILogger<Evaluator> logger;
         private readonly ILoggerFactory loggerFactory;
         private readonly IRepository repository;
-        private IPollingProcessor poller;
+        private readonly IPollingProcessor poller;
 
 
         public Evaluator(IRepository repository, IEvaluatorCallback callback, ILoggerFactory loggerFactory,

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -95,11 +95,13 @@ namespace io.harness.cfsdk.client.api
                 logger.LogWarning(
                     "Unable to find flag {Key} in cache, refreshing flag cache and retrying evaluation ",
                     key);
-                var refreshSuccess = poller.RefreshFlags(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
+                var refreshResult = poller.RefreshFlags(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
 
-                if (refreshSuccess)
-                    // Re-attempt to fetch the feature config after the refresh
-                    featureConfig = repository.GetFlag(key);
+                if (refreshResult != RefreshOutcome.Success)
+                    return null;
+
+                // Re-attempt to fetch the feature config after the refresh
+                featureConfig = repository.GetFlag(key);
 
                 // If still not found or doesn't match the kind, return null to indicate failure
                 if (featureConfig == null)

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -34,10 +34,11 @@ namespace io.harness.cfsdk.client.api
         private readonly ILoggerFactory loggerFactory;
         private readonly IRepository repository;
         private readonly IPollingProcessor poller;
+        private readonly Config config;
 
 
         public Evaluator(IRepository repository, IEvaluatorCallback callback, ILoggerFactory loggerFactory,
-            bool isAnalyticsEnabled, IPollingProcessor poller)
+            bool isAnalyticsEnabled, IPollingProcessor poller, Config config)
         {
             this.repository = repository;
             this.callback = callback;
@@ -45,6 +46,7 @@ namespace io.harness.cfsdk.client.api
             this.loggerFactory = loggerFactory;
             IsAnalyticsEnabled = isAnalyticsEnabled;
             this.poller = poller;
+            this.config = config;
         }
 
         public bool BoolVariation(string key, Target target, bool defaultValue)
@@ -93,7 +95,7 @@ namespace io.harness.cfsdk.client.api
                 logger.LogWarning(
                     "Unable to find flag {Key} in cache, refreshing flag cache and retrying evaluation ",
                     key);
-                var refreshSuccess = poller.RefreshFlags(TimeSpan.FromSeconds(2));
+                var refreshSuccess = poller.RefreshFlags(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
 
                 if (refreshSuccess)
                     // Re-attempt to fetch the feature config after the refresh

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -213,7 +213,7 @@ namespace io.harness.cfsdk.client.api
             EvaluationChanged?.Invoke(parent, identifier);
         }
 
-        public bool BoolVariation(string key, dto.Target target, bool defaultValue)
+        public bool BoolVariation(string key, Target target, bool defaultValue)
         {
             try
             {
@@ -221,15 +221,17 @@ namespace io.harness.cfsdk.client.api
             }
             catch (InvalidCacheStateException ex)
             {
-                logger.LogWarning(ex, "Invalid cache state detected when evaluating boolean variation for flag {Key}, refreshing cache and retrying evaluation ",
+                logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating boolean variation for flag {Key}, refreshing cache and retrying evaluation ",
                     key);
                 // Attempt to refresh cache
                 var success = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(2));
-                
+
                 // If the refresh has failed or exceeded the timout, return default variation
                 if (!success)
                 {
-                    logger.LogError(ex, "Refreshing cache for boolean variation for flag {Key} failed, returning default variation ",
+                    logger.LogError(ex,
+                        "Refreshing cache for boolean variation for flag {Key} failed, returning default variation ",
                         key);
                     LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
                     return defaultValue;
@@ -241,7 +243,8 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch (InvalidCacheStateException)
                 {
-                    logger.LogError(ex, "Attempted re-evaluation of boolean variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                    logger.LogError(ex,
+                        "Attempted re-evaluation of boolean variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
                         key);
                     LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
                     return defaultValue;
@@ -249,7 +252,7 @@ namespace io.harness.cfsdk.client.api
             }
         }
 
-        public string StringVariation(string key, dto.Target target, string defaultValue)
+        public string StringVariation(string key, Target target, string defaultValue)
         {
             try
             {
@@ -257,12 +260,14 @@ namespace io.harness.cfsdk.client.api
             }
             catch (InvalidCacheStateException ex)
             {
-                logger.LogWarning(ex, "Invalid cache state detected when evaluating string variation for flag {Key}, refreshing cache and retrying evaluation",
+                logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating string variation for flag {Key}, refreshing cache and retrying evaluation",
                     key);
                 var success = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(2));
                 if (!success)
                 {
-                    logger.LogError("Refreshing cache for string variation for flag {Key} failed, returning default variation",
+                    logger.LogError(
+                        "Refreshing cache for string variation for flag {Key} failed, returning default variation",
                         key);
                     LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
                     return defaultValue;
@@ -274,7 +279,8 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch (InvalidCacheStateException)
                 {
-                    logger.LogWarning("Attempted re-evaluation of string variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                    logger.LogWarning(
+                        "Attempted re-evaluation of string variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
                         key);
                     LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
                     return defaultValue;
@@ -291,12 +297,14 @@ namespace io.harness.cfsdk.client.api
             }
             catch (InvalidCacheStateException ex)
             {
-                logger.LogWarning(ex, "Invalid cache state detected when evaluating number variation for flag {Key}, refreshing cache and retrying evaluation",
+                logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating number variation for flag {Key}, refreshing cache and retrying evaluation",
                     key);
                 var success = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(2));
                 if (!success)
                 {
-                    logger.LogError("Refreshing cache for number variation for flag {Key} failed, returning default variation",
+                    logger.LogError(
+                        "Refreshing cache for number variation for flag {Key} failed, returning default variation",
                         key);
                     LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
                     return defaultValue;
@@ -308,7 +316,8 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch (InvalidCacheStateException)
                 {
-                    logger.LogWarning("Attempted re-evaluation of number variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                    logger.LogWarning(
+                        "Attempted re-evaluation of number variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
                         key);
                     LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
                     return defaultValue;
@@ -325,12 +334,14 @@ namespace io.harness.cfsdk.client.api
             }
             catch (InvalidCacheStateException ex)
             {
-                logger.LogWarning(ex, "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
+                logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
                     key);
                 var success = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(2));
                 if (!success)
                 {
-                    logger.LogError("Refreshing cache for json variation for flag {Key} failed, returning default variation",
+                    logger.LogError(
+                        "Refreshing cache for json variation for flag {Key} failed, returning default variation",
                         key);
                     LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                     return defaultValue;
@@ -342,7 +353,8 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch (InvalidCacheStateException)
                 {
-                    logger.LogWarning("Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                    logger.LogWarning(
+                        "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
                         key);
                     LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                     return defaultValue;

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -227,10 +227,10 @@ namespace io.harness.cfsdk.client.api
                     "Invalid cache state detected when evaluating boolean variation for flag {Key}, refreshing cache and retrying evaluation ",
                     key);
                 // Attempt to refresh cache
-                var success = polling.RefreshFlagsAndSegments(TimeSpan.FromMilliseconds(2000));
+                var result = polling.RefreshFlagsAndSegments(TimeSpan.FromMilliseconds(2000));
 
                 // If the refresh has failed or exceeded the timout, return default variation
-                if (!success)
+                if (result != RefreshOutcome.Success)
                 {
                     logger.LogError(ex,
                         "Refreshing cache for boolean variation for flag {Key} failed, returning default variation ",
@@ -265,8 +265,8 @@ namespace io.harness.cfsdk.client.api
                 logger.LogWarning(ex,
                     "Invalid cache state detected when evaluating string variation for flag {Key}, refreshing cache and retrying evaluation",
                     key);
-                var success = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
-                if (!success)
+                var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
+                if (result != RefreshOutcome.Success)
                 {
                     logger.LogError(
                         "Refreshing cache for string variation for flag {Key} failed, returning default variation",
@@ -302,8 +302,8 @@ namespace io.harness.cfsdk.client.api
                 logger.LogWarning(ex,
                     "Invalid cache state detected when evaluating number variation for flag {Key}, refreshing cache and retrying evaluation",
                     key);
-                var success = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
-                if (!success)
+                var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
+                if (result != RefreshOutcome.Success)
                 {
                     logger.LogError(
                         "Refreshing cache for number variation for flag {Key} failed, returning default variation",
@@ -339,8 +339,8 @@ namespace io.harness.cfsdk.client.api
                 logger.LogWarning(ex,
                     "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
                     key);
-                var success = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
-                if (!success)
+                var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
+                if (result != RefreshOutcome.Success)
                 {
                     logger.LogError(
                         "Refreshing cache for json variation for flag {Key} failed, returning default variation",

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -81,7 +81,7 @@ namespace io.harness.cfsdk.client.api
             this.repository = new StorageRepository(config.Cache, config.Store, this, loggerFactory);
             this.polling = new PollingProcessor(connector, this.repository, config, this, loggerFactory);
             this.update = new UpdateProcessor(connector, this.repository, config, this, loggerFactory);
-            this.evaluator = new Evaluator(this.repository, this, loggerFactory, config.analyticsEnabled);
+            this.evaluator = new Evaluator(this.repository, this, loggerFactory, config.analyticsEnabled, polling);
             // Since 1.4.2, we enable the global target for evaluation metrics. 
             this.metric = new MetricsProcessor(config, evaluationAnalyticsCache, targetAnalyticsCache, new AnalyticsPublisherService(connector, evaluationAnalyticsCache, targetAnalyticsCache, loggerFactory), loggerFactory, true);
             Start();

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -52,6 +52,11 @@ namespace io.harness.cfsdk.client.api
         private readonly Config config;
         private Timer pollTimer;
         private bool isInitialized = false;
+        private readonly object cacheRefreshLock = new object();
+        private DateTime lastCacheRefreshTime = DateTime.MinValue;
+        private const int MaxCacheRefreshTime = 60;
+
+        private readonly TimeSpan refreshCooldown = TimeSpan.FromSeconds(MaxCacheRefreshTime);
 
         public PollingProcessor(IConnector connector, IRepository repository, Config config, IPollCallback callback, ILoggerFactory loggerFactory)
         {

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -10,8 +10,8 @@
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <Version>1.6.4</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.6.4</PackageVersion>
-        <AssemblyVersion>1.6.4</AssemblyVersion>
+        <PackageVersion>1.6.5</PackageVersion>
+        <AssemblyVersion>1.6.5</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>


### PR DESCRIPTION
# What
This adds cache recovery mechanism for flags and groups in the following ways (note the recovery can't be triggered more than once per minute to avoid overloading our API): 

## Groups
Since a group cache lookup is determined by the flag, and if it's missing from the cache then we know the cache state is invalid, we now trigger one group cache refresh with timeout and a warning log, and attempt to evaluate one final time. If the same error occurs and we can't find the group even after a refresh, we return the default variation and log an error.

## Flags
Not finding a flag in the cache doesn't necessarily mean invalid state; the user may have supplied a flag ID that doesn't exist in their project.  However, if the flag can't be found we attempt one refresh of the flag cache with timeout  + warning log. if it is now found, we continue with the evaluation. If it can't be found, we return the default variation.  

Includes new config option `SetCacheRecoveryTimeout(int timeoutMilliseconds)` which defaults to 5 seconds. 

# Testing
- Ran through TestGrid evaluation suite
- Flags: Manual - prod 2 - supplied wrong flag name and it attempted once before returning default. 
- Groups: Manual - prod 2, using a contrived example where I hardcode the group name to be something that won't exist. It attempts the refresh and returns the default variation if still can't be found. 
