### PR TITLE
chore(License): Update to use PackageLicenseExpression

### DIFF
--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -15,7 +15,7 @@
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
-        <PackageLicenseUrl>https://github.com/drone/ff-dotnet-server-sdk/blob/main/LICENSE</PackageLicenseUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageProjectUrl>https://github.com/drone/ff-dotnet-server-sdk</PackageProjectUrl>
         <Summary>.NET Server SDK for Harness Feature Flag platform</Summary>


### PR DESCRIPTION
Security scanners work off the `PackageLicenseExpression` Property ([see deprecation info re `PackageLicenseUrl`](https://learn.microsoft.com/en-us/nuget/reference/nuspec#licenseurl))

Because you're using a straight Apache 2.0 license, you can just express that compliance via this expression

Ultimately the property propagates such that the nupgk bears the expression, and [nuget.org renders and extra line expressing this](https://www.nuget.org/packages/equinox.cosmosstore)

<img width="236" alt="image" src="https://github.com/harness/ff-dotnet-server-sdk/assets/206668/01c6653a-23f7-4472-a850-28ebc8779bfe">
