### PR TITLE
FFM-11509 Make `System.Net.Http` conditional 

### DIFF
--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,9 +8,9 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.0</Version>
+        <Version>1.7.0-rc1</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.0</PackageVersion>
+        <PackageVersion>1.7.0-rc1</PackageVersion>
         <AssemblyVersion>1.7.0</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -39,7 +39,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'" />
         <PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# What
Makes `System.Net.Http` a conditional import where it is only included for `net461` and `netstandard2.0`

# Why
`System.Net.Http` is included in .NET 5.0 onwards and is a redundant import, but we should still include it for the older TFMs we support to ensure backwards compatability

# Testing
Sample app using a lockfile to determine dependencies brought in by the SDK:
-  targeting .NET 5.0 / .NET 6.0 / .NET 7.0 using lock file 
![Screenshot 2024-05-21 at 15 28 56](https://github.com/harness/ff-dotnet-server-sdk/assets/23323369/d28df232-369b-40e4-ab01-2a6d7bed9982)


- targeting net461
- ![Screenshot 2024-05-21 at 15 31 51](https://github.com/harness/ff-dotnet-server-sdk/assets/23323369/819d3826-2364-4fa8-922b-a44d8d55055f)
