### PR TITLE
FFM-11537 Handle null target for target metrics + test

### DIFF
--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -99,7 +99,6 @@ namespace io.harness.cfsdk.client.api.analytics
 
             if (target == null || target.IsPrivate)
             {
-                // Target is marked as private, so don't send it in analytics
                 return;
             }
             

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -97,7 +97,7 @@ namespace io.harness.cfsdk.client.api.analytics
         private void PushToTargetAnalyticsCache(Target target)
         {
 
-            if (target.IsPrivate)
+            if (target == null || target.IsPrivate)
             {
                 // Target is marked as private, so don't send it in analytics
                 return;

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.0</Version>
+        <Version>1.6.9</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.0</PackageVersion>
-        <AssemblyVersion>1.7.0</AssemblyVersion>
+        <PackageVersion>1.6.9</PackageVersion>
+        <AssemblyVersion>1.6.9</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -52,6 +52,42 @@ namespace ff_server_sdk_test.api.analytics
             Assert.That(evaluationAnalyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
             Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
         }
+        
+        [Test]
+        public void Should_add_single_evaluation_and_no_target_for_null_target()
+        {
+            var evaluationAnalyticsCacheMock = new EvaluationAnalyticsCache();
+            var targetAnalyticsCacheMock = new TargetAnalyticsCache();
+            var connectorMock = new Mock<IConnector>();
+            var analyticsPublisherServiceMock =
+                new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
+                    targetAnalyticsCacheMock, new NullLoggerFactory());
+
+            var variation = new Variation();
+
+            var featureConfig1 = CreateFeatureConfig("feature1");
+            var evaluationAnalytics = new EvaluationAnalytics(featureConfig1, variation, null);
+            var targetAnalytics = new TargetAnalytics(null);
+
+            var sut = new MetricsProcessor(new Config(), evaluationAnalyticsCacheMock, targetAnalyticsCacheMock,
+                analyticsPublisherServiceMock,
+                new NullLoggerFactory(), false);
+
+
+            sut.PushToCache(null, featureConfig1, variation);
+
+            // Ensure the cache totals are correct
+            Assert.That(evaluationAnalyticsCacheMock.GetAllElements().Count, Is.EqualTo(1));
+            Assert.That(targetAnalyticsCacheMock.GetAllElements().Count, Is.EqualTo(0));
+
+
+            // Ensure the cache total and breakdown of the type of analytics is correct
+            Assert.That(evaluationAnalyticsCacheMock.GetAllElements().Count, Is.EqualTo(1));
+
+            // Ensure the counter is correct.
+            Assert.That(evaluationAnalyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
+            Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(0));
+        }
 
 
         [Test]


### PR DESCRIPTION
# What
Since 1.5.0, a null pointer exception would occur if an evaluation was made with a `null` target when checking if the target was valid to be stored in analytics. 
This PR adds a null check to fix the issue. 

# Testing
New unit test + manual sample app. 

Ran pipeline against PR 
![Screenshot 2024-05-22 at 12 41 33](https://github.com/harness/ff-dotnet-server-sdk/assets/23323369/ee72f3a8-0793-4a1c-9da7-8e49a6ef763a)
