### PR TITLE
[FFM-11557] - Wrap log statements with if statements

### DIFF
--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -93,9 +93,10 @@ namespace io.harness.cfsdk.client.api
             var featureConfig = repository.GetFlag(key);
             if (featureConfig == null)
             {
-                logger.LogWarning(
+                if (logger.IsEnabled(LogLevel.Warning))
+                    logger.LogWarning(
                     "Unable to find flag {Key} in cache, refreshing flag cache and retrying evaluation ",
-                    key);
+                     key);
 
                 if (poller != null)
                 {
@@ -111,16 +112,16 @@ namespace io.harness.cfsdk.client.api
                 // If still not found or doesn't match the kind, return null to indicate failure
                 if (featureConfig == null)
                 {
-                    logger.LogError(
-                        "Failed to find flag {Key} in cache even after attempting a refresh. Check flag exists in project",
-                        key);
+                    if (logger.IsEnabled(LogLevel.Error))
+                        logger.LogError("Failed to find flag {Key} in cache even after attempting a refresh. Check flag exists in project", key);
                     return null;
                 }
             }
 
             if (featureConfig.Kind != kind)
             {
-                logger.LogWarning(
+                if (logger.IsEnabled(LogLevel.Warning))
+                    logger.LogWarning(
                     "Requested variation {Kind} does not match flag {Key} which is of type {featureConfigKind}",
                     kind,  key, featureConfig.Kind);
                 return null;
@@ -194,12 +195,15 @@ namespace io.harness.cfsdk.client.api
                 logger.LogDebug(
                     "Evaluating specific targeting: Flag({@Flag})",
                     new { FeatureFlag = featureConfig});
+
             var specificTargetingVariation =
                 EvaluateVariationMap(target, featureConfig.VariationToTargetMap, featureConfig.Feature);
             if (specificTargetingVariation != null)
             {
-                logger.LogDebug("Specific targeting matched: Flag({@Flag}) Target({@Target})",
-                    new { FeatureFlag = featureConfig}, new { Target = target});
+                if (logger.IsEnabled(LogLevel.Debug))
+                    logger.LogDebug("Specific targeting matched: Flag({@Flag}) Target({@Target})",
+                        new { FeatureFlag = featureConfig}, new { Target = target});
+
                 return GetVariation(featureConfig.Variations, specificTargetingVariation);
             }
 
@@ -211,13 +215,16 @@ namespace io.harness.cfsdk.client.api
             var defaultVariation = featureConfig.DefaultServe.Variation;
             if (defaultVariation == null)
             {
-                logger.LogWarning("Default serve variation not found: Flag({@Flag})",
+                if (logger.IsEnabled(LogLevel.Warning))
+                    logger.LogWarning("Default serve variation not found: Flag({@Flag})",
                     new { Flag = featureConfig});
                 return null;
             }
 
-            logger.LogDebug("Default on rule matched: Target({@Target}) Flag({@Flag})",
-                new { Target = target}, new { Flag = featureConfig});
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("Default on rule matched: Target({@Target}) Flag({@Flag})",
+                    new { Target = target}, new { Flag = featureConfig});
+
             return GetVariation(featureConfig.Variations, defaultVariation);
         }
 
@@ -262,8 +269,10 @@ namespace io.harness.cfsdk.client.api
                 // Invalid state: Log if Clauses are null 
                 if (servingRule.Clauses == null)
                 {
-                    logger.LogWarning("Clauses are null for servingRule {RuleId} in FeatureConfig {@FeatureConfigId}",
+                    if (logger.IsEnabled(LogLevel.Warning))
+                        logger.LogWarning("Clauses are null for servingRule {RuleId} in FeatureConfig {@FeatureConfigId}",
                         servingRule.RuleId, new { Flag = featureConfig});
+
                     return null;
                 }
 
@@ -273,8 +282,10 @@ namespace io.harness.cfsdk.client.api
                 // Invalid state: Log if Serve is null
                 if (servingRule.Serve == null)
                 {
-                    logger.LogWarning("Serve is null for rule ID {Rule} in FeatureConfig {@FeatureConfig}",
+                    if (logger.IsEnabled(LogLevel.Warning))
+                        logger.LogWarning("Serve is null for rule ID {Rule} in FeatureConfig {@FeatureConfig}",
                         servingRule.RuleId, new { Flag = featureConfig});
+
                     return null;
                 }
 
@@ -294,7 +305,8 @@ namespace io.harness.cfsdk.client.api
                 // Invalid state: Log if the variation is null
                 if (servingRule.Serve.Variation == null)
                 {
-                    logger.LogWarning("Serve.Variation is null for a rule in Flag({@FeatureConfig})",
+                    if (logger.IsEnabled(LogLevel.Warning))
+                        logger.LogWarning("Serve.Variation is null for a rule in Flag({@FeatureConfig})",
                              new { Flag = featureConfig});
                         
                     return null;
@@ -319,8 +331,9 @@ namespace io.harness.cfsdk.client.api
                     throw new InvalidCacheStateException(
                         $"Segment with identifier {segmentIdentifier} could not be found in the cache despite belonging to the flag.");
 
-                logger.LogDebug("Evaluating group rule: Group({@Segment} Target({@Target}))",
-                    new { Segment = segment}, new { Target = target});
+                if (logger.IsEnabled(LogLevel.Debug))
+                    logger.LogDebug("Evaluating group rule: Group({@Segment} Target({@Target}))",
+            new { Segment = segment}, new { Target = target});
 
                 // check exclude list
                 if (segment.Excluded != null && segment.Excluded.Any(t => t.Identifier.Equals(target.Identifier)))

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -223,18 +223,19 @@ namespace io.harness.cfsdk.client.api
             }
             catch (InvalidCacheStateException ex)
             {
-                logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating boolean variation for flag {Key}, refreshing cache and retrying evaluation ",
-                    key);
+                if (logger.IsEnabled(LogLevel.Warning))
+                    logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating boolean variation for flag {Key}, refreshing cache and retrying evaluation ", key);
+
                 // Attempt to refresh cache
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromMilliseconds(2000));
 
                 // If the refresh has failed or exceeded the timout, return default variation
                 if (result != RefreshOutcome.Success)
                 {
-                    logger.LogError(ex,
-                        "Refreshing cache for boolean variation for flag {Key} failed, returning default variation ",
-                        key);
+                    if (logger.IsEnabled(LogLevel.Error))
+                        logger.LogError(ex, "Refreshing cache for boolean variation for flag {Key} failed, returning default variation ", key);
+
                     LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
                     return defaultValue;
                 }
@@ -245,9 +246,11 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch (InvalidCacheStateException)
                 {
-                    logger.LogError(ex,
-                        "Attempted re-evaluation of boolean variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                        key);
+                    if (logger.IsEnabled(LogLevel.Error))
+                        logger.LogError(ex,
+                            "Attempted re-evaluation of boolean variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                            key);
+
                     LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
                     return defaultValue;
                 }
@@ -262,15 +265,18 @@ namespace io.harness.cfsdk.client.api
             }
             catch (InvalidCacheStateException ex)
             {
-                logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating string variation for flag {Key}, refreshing cache and retrying evaluation",
-                    key);
+                if (logger.IsEnabled(LogLevel.Warning))
+                    logger.LogWarning(ex,
+                        "Invalid cache state detected when evaluating string variation for flag {Key}, refreshing cache and retrying evaluation",
+                        key);
+
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
                 if (result != RefreshOutcome.Success)
                 {
-                    logger.LogError(
-                        "Refreshing cache for string variation for flag {Key} failed, returning default variation",
-                        key);
+                    if (logger.IsEnabled(LogLevel.Error))
+                        logger.LogError(
+                            "Refreshing cache for string variation for flag {Key} failed, returning default variation",
+                            key);
                     LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
                     return defaultValue;
                 }
@@ -281,9 +287,10 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch (InvalidCacheStateException)
                 {
-                    logger.LogWarning(
-                        "Attempted re-evaluation of string variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                        key);
+                    if (logger.IsEnabled(LogLevel.Warning))
+                        logger.LogWarning(
+                            "Attempted re-evaluation of string variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                            key);
                     LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
                     return defaultValue;
                 }
@@ -299,15 +306,18 @@ namespace io.harness.cfsdk.client.api
             }
             catch (InvalidCacheStateException ex)
             {
-                logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating number variation for flag {Key}, refreshing cache and retrying evaluation",
-                    key);
+                if (logger.IsEnabled(LogLevel.Warning))
+                    logger.LogWarning(ex,
+                        "Invalid cache state detected when evaluating number variation for flag {Key}, refreshing cache and retrying evaluation",
+                        key);
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
                 if (result != RefreshOutcome.Success)
                 {
-                    logger.LogError(
-                        "Refreshing cache for number variation for flag {Key} failed, returning default variation",
-                        key);
+                    if (logger.IsEnabled(LogLevel.Error))
+                        logger.LogError(
+                            "Refreshing cache for number variation for flag {Key} failed, returning default variation",
+                            key);
+
                     LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
                     return defaultValue;
                 }
@@ -318,9 +328,10 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch (InvalidCacheStateException)
                 {
-                    logger.LogWarning(
-                        "Attempted re-evaluation of number variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                        key);
+                    if (logger.IsEnabled(LogLevel.Warning))
+                        logger.LogWarning(
+                            "Attempted re-evaluation of number variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                            key);
                     LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
                     return defaultValue;
                 }
@@ -336,15 +347,17 @@ namespace io.harness.cfsdk.client.api
             }
             catch (InvalidCacheStateException ex)
             {
-                logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
-                    key);
+                if (logger.IsEnabled(LogLevel.Warning))
+                    logger.LogWarning(ex,
+                        "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
+                        key);
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
                 if (result != RefreshOutcome.Success)
                 {
-                    logger.LogError(
-                        "Refreshing cache for json variation for flag {Key} failed, returning default variation",
-                        key);
+                    if (logger.IsEnabled(LogLevel.Error))
+                        logger.LogError(
+                            "Refreshing cache for json variation for flag {Key} failed, returning default variation",
+                            key);
                     LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                     return defaultValue;
                 }
@@ -355,9 +368,10 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch (InvalidCacheStateException)
                 {
-                    logger.LogWarning(
-                        "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                        key);
+                    if (logger.IsEnabled(LogLevel.Warning))
+                        logger.LogWarning(
+                            "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                            key);
                     LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                     return defaultValue;
                 }


### PR DESCRIPTION
[FFM-11557] - Wrap log statements with if statements

**What**
Wrap some debug statements on the evaluation path with if statements so they don't get run when logging is disabled for that level. Also wrapped some warning loggers too

**Why**
We're seeing debug logs creating noise on the heap when log level is set to something higher. We want to prevent unnecessary objects on the heap/work for the GC.

**Testing**
Load + Testgrid

[FFM-11557]: https://harness.atlassian.net/browse/FFM-11557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ