### PR TITLE
FFM-11549 SeenTargets cache memory improvements

### DIFF
--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -224,10 +224,12 @@ namespace io.harness.cfsdk.client.api
 
         /**
          * <summary>
-         *     The SeenTargetsCache is used to reduce analytics payload size the SDK sends to the Feature Flags Service.
-         *     Set maximum number of unique targets that will be stored in the SeenTargets cache. Defaults to 500,000
-         *     unique targets.  You can increase or decrease this number depending on your memory requirements. 
+         *     The SeenTargetsCache helps to reduce the size of the analytics payload that the SDK sends to the Feature Flags Service.
+         *     This method allows you to set the maximum number of unique targets that will be stored in the SeenTargets cache.
+         *     By default, the limit is set to 500,000 unique targets. You can increase this number if you need to handle more than
+         *     500,000 targets, which will reduce the payload size but will also increase memory usage.
          * </summary>
+         * <param name="seenTargetsCacheLimit">The maximum number of unique targets to store in the cache.</param>
          */
         public ConfigBuilder SeenTargetsCacheLimit(int seenTargetsCacheLimit)
         {
@@ -237,11 +239,12 @@ namespace io.harness.cfsdk.client.api
 
         /**
          * <summary>
-         *     Set custom TTL for SeenTargets map keys. The default value is 43200 seconds, or 12 hours.  If you have
-         *     a large number of targets and would prefer to clear this map sooner, decrease this TTL to free up memory.
-         *     SeenTargets is used to reduce payload size to the Feature Flags Analytics service, so clearing it more frequently
-         *     could result in larger payload sizes.
+         *     Sets a custom Time-To-Live (TTL) for keys in the SeenTargets map. The default TTL is 43,200 seconds (12 hours).
+         *     If you have a large number of targets and want to clear the map more frequently to free up memory, you can decrease this TTL.
+         *     However, be aware that reducing the TTL will lead to more frequent cache clears, which can result in larger payload sizes
+         *     being sent to the Feature Flags Analytics service.
          * </summary>
+         * <param name="seenTargetsCacheTtlInSeconds">The TTL for keys in the SeenTargets map, in seconds.</param>
          */
         public ConfigBuilder SeenTargetsCacheTtlInSeconds(int seenTargetsCacheTtlInSeconds)
         {

--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -24,12 +24,12 @@ namespace io.harness.cfsdk.client.api
         internal int targetMetricsMaxSize = 100000;
         internal int cacheRecoveryTimeoutInMs = 5000;
         internal bool useMapForInClause = false;
-        internal int seenTargetsTtlInSeconds = 43200;
-        internal int seenTargetsLimit = 500000;
+        internal int seenTargetsCacheTtlInSeconds = 43200;
+        internal int seenTargetsCacheLimit = 500000;
 
         public Config(string configUrl, string eventUrl, bool streamEnabled, int pollIntervalInSeconds,
             bool analyticsEnabled, int frequency, int targetMetricsMaxSize, int connectionTimeout, int readTimeout,
-            int writeTimeout, bool debug, long metricsServiceAcceptableDuration, int cacheRecoveryTimeoutInMs, bool useMapForInClause, int seenTargetsLimit, int seenTargetsTtlInSeconds)
+            int writeTimeout, bool debug, long metricsServiceAcceptableDuration, int cacheRecoveryTimeoutInMs, bool useMapForInClause, int seenTargetsCacheLimit, int seenTargetsCacheTtlInSeconds)
         {
             this.configUrl = configUrl;
             this.eventUrl = eventUrl;
@@ -45,8 +45,8 @@ namespace io.harness.cfsdk.client.api
             this.metricsServiceAcceptableDuration = metricsServiceAcceptableDuration;
             this.cacheRecoveryTimeoutInMs = cacheRecoveryTimeoutInMs;
             this.useMapForInClause = useMapForInClause;
-            this.seenTargetsLimit = seenTargetsLimit;
-            this.seenTargetsTtlInSeconds = seenTargetsTtlInSeconds;
+            this.seenTargetsCacheLimit = seenTargetsCacheLimit;
+            this.seenTargetsCacheTtlInSeconds = seenTargetsCacheTtlInSeconds;
         }
 
         public Config()
@@ -75,9 +75,9 @@ namespace io.harness.cfsdk.client.api
         public int CacheRecoveryTimeoutInMs => cacheRecoveryTimeoutInMs;
 
         public bool UseMapForInClause => useMapForInClause;
-        public int SeenTargetsLimit => seenTargetsLimit;
+        public int SeenTargetsCacheLimit => seenTargetsCacheLimit;
 
-        public int SeenTargetsTtlInSeconds => seenTargetsTtlInSeconds;
+        public int SeenTargetsCacheTtlInSeconds => seenTargetsCacheTtlInSeconds;
 
         /**
          * timeout in milliseconds to connect to CF Server
@@ -229,9 +229,9 @@ namespace io.harness.cfsdk.client.api
          *     unique targets.  You can increase or decrease this number depending on your memory requirements. 
          * </summary>
          */
-        public ConfigBuilder SeenTargetsLimit(int seenTargetsLimit)
+        public ConfigBuilder SeenTargetsCacheLimit(int seenTargetsCacheLimit)
         {
-            configtobuild.seenTargetsLimit = seenTargetsLimit;
+            configtobuild.seenTargetsCacheLimit = seenTargetsCacheLimit;
             return this;
         }
 
@@ -243,9 +243,9 @@ namespace io.harness.cfsdk.client.api
          *     could result in larger payload sizes.
          * </summary>
          */
-        public ConfigBuilder SeenTargetsTtlInSeconds(int seenTargetsTtlInSeconds)
+        public ConfigBuilder SeenTargetsCacheTtlInSeconds(int seenTargetsCacheTtlInSeconds)
         {
-            configtobuild.seenTargetsTtlInSeconds = seenTargetsTtlInSeconds;
+            configtobuild.seenTargetsCacheTtlInSeconds = seenTargetsCacheTtlInSeconds;
             return this;
         }
 

--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -25,10 +25,11 @@ namespace io.harness.cfsdk.client.api
         internal int cacheRecoveryTimeoutInMs = 5000;
         internal bool useMapForInClause = false;
         internal int seenTargetsTtlInSeconds = 43200;
+        internal int seenTargetsLimit = 500000;
 
         public Config(string configUrl, string eventUrl, bool streamEnabled, int pollIntervalInSeconds,
             bool analyticsEnabled, int frequency, int targetMetricsMaxSize, int connectionTimeout, int readTimeout,
-            int writeTimeout, bool debug, long metricsServiceAcceptableDuration, int cacheRecoveryTimeoutInMs, bool useMapForInClause, int seenTargetsTtlInSeconds)
+            int writeTimeout, bool debug, long metricsServiceAcceptableDuration, int cacheRecoveryTimeoutInMs, bool useMapForInClause, int seenTargetsLimit, int seenTargetsTtlInSeconds)
         {
             this.configUrl = configUrl;
             this.eventUrl = eventUrl;
@@ -44,6 +45,7 @@ namespace io.harness.cfsdk.client.api
             this.metricsServiceAcceptableDuration = metricsServiceAcceptableDuration;
             this.cacheRecoveryTimeoutInMs = cacheRecoveryTimeoutInMs;
             this.useMapForInClause = useMapForInClause;
+            this.seenTargetsLimit = seenTargetsLimit;
             this.seenTargetsTtlInSeconds = seenTargetsTtlInSeconds;
         }
 
@@ -73,6 +75,8 @@ namespace io.harness.cfsdk.client.api
         public int CacheRecoveryTimeoutInMs => cacheRecoveryTimeoutInMs;
 
         public bool UseMapForInClause => useMapForInClause;
+        public int SeenTargetsLimit => seenTargetsLimit;
+
         public int SeenTargetsTtlInSeconds => seenTargetsTtlInSeconds;
 
         /**
@@ -220,10 +224,23 @@ namespace io.harness.cfsdk.client.api
 
         /**
          * <summary>
+         *     The SeenTargetsCache is used to reduce analytics payload size the SDK sends to the Feature Flags Service.
+         *     Set maximum number of unique targets that will be stored in the SeenTargets cache. Defaults to 500,000
+         *     unique targets.  You can increase or decrease this number depending on your memory requirements. 
+         * </summary>
+         */
+        public ConfigBuilder SeenTargetsLimit(int seenTargetsLimit)
+        {
+            configtobuild.seenTargetsLimit = seenTargetsLimit;
+            return this;
+        }
+
+        /**
+         * <summary>
          *     Set custom TTL for SeenTargets map keys. The default value is 43200 seconds, or 12 hours.  If you have
          *     a large number of targets and would prefer to clear this map sooner, decrease this TTL to free up memory.
          *     SeenTargets is used to reduce payload size to the Feature Flags Analytics service, so clearing it more frequently
-         *     could result in larger payload sizes. 
+         *     could result in larger payload sizes.
          * </summary>
          */
         public ConfigBuilder SeenTargetsTtlInSeconds(int seenTargetsTtlInSeconds)

--- a/client/api/Config.cs
+++ b/client/api/Config.cs
@@ -24,10 +24,11 @@ namespace io.harness.cfsdk.client.api
         internal int targetMetricsMaxSize = 100000;
         internal int cacheRecoveryTimeoutInMs = 5000;
         internal bool useMapForInClause = false;
+        internal int seenTargetsTtlInSeconds = 43200;
 
         public Config(string configUrl, string eventUrl, bool streamEnabled, int pollIntervalInSeconds,
             bool analyticsEnabled, int frequency, int targetMetricsMaxSize, int connectionTimeout, int readTimeout,
-            int writeTimeout, bool debug, long metricsServiceAcceptableDuration, int cacheRecoveryTimeoutInMs, bool useMapForInClause)
+            int writeTimeout, bool debug, long metricsServiceAcceptableDuration, int cacheRecoveryTimeoutInMs, bool useMapForInClause, int seenTargetsTtlInSeconds)
         {
             this.configUrl = configUrl;
             this.eventUrl = eventUrl;
@@ -43,6 +44,7 @@ namespace io.harness.cfsdk.client.api
             this.metricsServiceAcceptableDuration = metricsServiceAcceptableDuration;
             this.cacheRecoveryTimeoutInMs = cacheRecoveryTimeoutInMs;
             this.useMapForInClause = useMapForInClause;
+            this.seenTargetsTtlInSeconds = seenTargetsTtlInSeconds;
         }
 
         public Config()
@@ -71,6 +73,7 @@ namespace io.harness.cfsdk.client.api
         public int CacheRecoveryTimeoutInMs => cacheRecoveryTimeoutInMs;
 
         public bool UseMapForInClause => useMapForInClause;
+        public int SeenTargetsTtlInSeconds => seenTargetsTtlInSeconds;
 
         /**
          * timeout in milliseconds to connect to CF Server
@@ -214,6 +217,21 @@ namespace io.harness.cfsdk.client.api
             configtobuild.useMapForInClause = useMapForInClause;
             return this;
         }
+
+        /**
+         * <summary>
+         *     Set custom TTL for SeenTargets map keys. The default value is 43200 seconds, or 12 hours.  If you have
+         *     a large number of targets and would prefer to clear this map sooner, decrease this TTL to free up memory.
+         *     SeenTargets is used to reduce payload size to the Feature Flags Analytics service, so clearing it more frequently
+         *     could result in larger payload sizes. 
+         * </summary>
+         */
+        public ConfigBuilder SeenTargetsTtlInSeconds(int seenTargetsTtlInSeconds)
+        {
+            configtobuild.seenTargetsTtlInSeconds = seenTargetsTtlInSeconds;
+            return this;
+        }
+
 
         /// <summary>
         /// <para>

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -85,7 +85,7 @@ namespace io.harness.cfsdk.client.api
             this.update = new UpdateProcessor(connector, this.repository, config, this, loggerFactory);
             this.evaluator = new Evaluator(this.repository, this, loggerFactory, config.analyticsEnabled, polling, config);
             // Since 1.4.2, we enable the global target for evaluation metrics. 
-            this.metric = new MetricsProcessor(config, evaluationAnalyticsCache, targetAnalyticsCache, new AnalyticsPublisherService(connector, evaluationAnalyticsCache, targetAnalyticsCache, loggerFactory), loggerFactory, true);
+            this.metric = new MetricsProcessor(config, evaluationAnalyticsCache, targetAnalyticsCache, new AnalyticsPublisherService(connector, evaluationAnalyticsCache, targetAnalyticsCache, loggerFactory, config), loggerFactory, true);
             Start();
         }
         internal void Start()

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -131,15 +131,19 @@ namespace io.harness.cfsdk.client.api.analytics
             {
                 return;
             }
-            
-            logger.LogWarning(
-                "{cacheType} frequency map exceeded buffer size ({cacheSize} > {bufferSize}), not sending any further" +
-                " {cacheType} metrics for interval. Increase buffer size using client config option if required.", cacheType,
-                cacheSize,
-                bufferSize,
-                cacheType);
-            
-            warningLoggedForInterval = true;
+
+            if (logger.IsEnabled(LogLevel.Warning))
+            {
+                logger.LogWarning(
+                    "{cacheType} frequency map exceeded buffer size ({cacheSize} > {bufferSize}), not sending any further" +
+                    " {cacheType} metrics for interval. Increase buffer size using client config option if required.",
+                    cacheType,
+                    cacheSize,
+                    bufferSize,
+                    cacheType);
+
+                warningLoggedForInterval = true;
+            }
         }
 
         internal void Timer_Elapsed(object sender, ElapsedEventArgs e)

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -4,6 +4,7 @@ using io.harness.cfsdk.client.dto;
 using io.harness.cfsdk.HarnessOpenAPIService;
 using Microsoft.Extensions.Logging;
 using Target = io.harness.cfsdk.client.dto.Target;
+using Timer = System.Timers.Timer;
 
 namespace io.harness.cfsdk.client.api.analytics
 {
@@ -127,12 +128,11 @@ namespace io.harness.cfsdk.client.api.analytics
         private void LogMetricsIgnoredWarning(string cacheType, int cacheSize, int bufferSize)
         {
             // Only log this once per interval
-            if (warningLoggedForInterval)
+            if (warningLoggedForInterval || !logger.IsEnabled(LogLevel.Warning))
             {
                 return;
             }
 
-            if (logger.IsEnabled(LogLevel.Warning))
             {
                 logger.LogWarning(
                     "{cacheType} frequency map exceeded buffer size ({cacheSize} > {bufferSize}), not sending any further" +
@@ -148,7 +148,8 @@ namespace io.harness.cfsdk.client.api.analytics
 
         internal void Timer_Elapsed(object sender, ElapsedEventArgs e)
         {
-            logger.LogDebug("Timer Elapsed - Processing/Sending analytics data");
+            if (logger.IsEnabled(LogLevel.Debug))
+                logger.LogDebug("Timer Elapsed - Processing/Sending analytics data");
             SendMetrics();
         }
 
@@ -161,7 +162,8 @@ namespace io.harness.cfsdk.client.api.analytics
             }
             catch (CfClientException ex)
             {
-                logger.LogError(ex, "Failed to send analytics data to server");
+                if (logger.IsEnabled(LogLevel.Error))
+                    logger.LogError(ex, "Failed to send analytics data to server");
             }
         }
     }

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -118,12 +118,8 @@ namespace io.harness.cfsdk.client.api.analytics
             }
 
             TargetAnalytics targetAnalytics = new TargetAnalytics(target);
-
-            // We don't need to keep count of targets, so use a constant value, 1, for the count. 
-            // Since 1.4.2, the analytics cache was refactored to separate out Evaluation and Target metrics, but the 
-            // change did not go as far as to maintain two caches (due to effort involved), but differentiate them based on subclassing, so 
-            // the counter used for target metrics isn't needed, but causes no issue. 
-            targetAnalyticsCache.Put(targetAnalytics, 1);
+            
+            targetAnalyticsCache.Put(targetAnalytics);
 
             analyticsPublisherService.MarkTargetAsSeen(target);
         }

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -102,7 +102,7 @@ namespace io.harness.cfsdk.client.api.analytics
                 return;
             }
             
-            if (analyticsPublisherService.IsTargetSeen(target))
+            if (analyticsPublisherService.IsTargetSeen(target.Identifier))
             {
                 // Target has already been processed in a previous interval, so ignore it.
                 return;
@@ -121,7 +121,7 @@ namespace io.harness.cfsdk.client.api.analytics
             
             targetAnalyticsCache.Put(targetAnalytics);
 
-            analyticsPublisherService.MarkTargetAsSeen(target);
+            analyticsPublisherService.MarkTargetAsSeen(target.Identifier);
         }
 
         private void LogMetricsIgnoredWarning(string cacheType, int cacheSize, int bufferSize)

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -97,7 +97,7 @@ namespace io.harness.cfsdk.client.api.analytics
         private void PushToTargetAnalyticsCache(Target target)
         {
 
-            if (target == null || target.IsPrivate)
+            if (target?.Identifier == null || target.IsPrivate)
             {
                 return;
             }

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -43,12 +43,14 @@ namespace io.harness.cfsdk.client.api.analytics
         {
             if (config.analyticsEnabled)
             {
+                // Metrics thread timer
                 timer = new Timer((long)config.Frequency * 1000);
                 timer.Elapsed += Timer_Elapsed;
                 timer.AutoReset = true;
                 timer.Enabled = true;
                 timer.Start();
                 
+                // SeenTargetsCache timer
                 seenTargetsCacheResetTimer = new Timer(config.seenTargetsCacheTtlInSeconds);
                 seenTargetsCacheResetTimer.Elapsed += SeenTargetsCacheResetTimer_Elapsed;
                 seenTargetsCacheResetTimer.AutoReset = true;

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -20,7 +20,7 @@ namespace io.harness.cfsdk.client.api.analytics
         private static readonly string Server = "server";
         private static readonly string SdkLanguage = "SDK_LANGUAGE";
         private static readonly string SdkVersion = "SDK_VERSION";
-        internal readonly ConcurrentDictionary<Target, byte> SeenTargets = new();
+        internal readonly SeenTargetsCache SeenTargets = new();
         private readonly IConnector connector;
         private readonly EvaluationAnalyticsCache evaluationAnalyticsCache;
         private readonly ILogger<AnalyticsPublisherService> logger;
@@ -67,7 +67,7 @@ namespace io.harness.cfsdk.client.api.analytics
         }
 
         private Metrics PrepareMessageBody(IDictionary<EvaluationAnalytics, int> evaluationsCache,
-            IDictionary<TargetAnalytics, int> targetsCache)
+            IDictionary<TargetAnalytics, bool> targetsCache)
         {
             var metrics = new Metrics();
             metrics.TargetData = new List<TargetData>();
@@ -119,16 +119,16 @@ namespace io.harness.cfsdk.client.api.analytics
             return metrics;
         }
         
-        public bool IsTargetSeen(Target target)
+        public bool IsTargetSeen(string identifier)
         {
-            return SeenTargets.ContainsKey(target);
-        }
-        
-        public void MarkTargetAsSeen(Target target)
-        {
-            SeenTargets.TryAdd(target, 0);
+            return SeenTargets.getIfPresent(identifier);
         }
 
+        public void MarkTargetAsSeen(string identifier)
+
+        {
+            SeenTargets.Put(identifier);
+        }
 
         private void SetCommonSdkAttributes(MetricsData metricsData)
         {

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -30,7 +30,7 @@ namespace io.harness.cfsdk.client.api.analytics
 
         public AnalyticsPublisherService(IConnector connector, EvaluationAnalyticsCache evaluationAnalyticsCache,
             TargetAnalyticsCache targetAnalyticsCache,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory, Config config)
         {
             this.evaluationAnalyticsCache = evaluationAnalyticsCache;
             this.targetAnalyticsCache = targetAnalyticsCache;

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -69,7 +69,8 @@ namespace io.harness.cfsdk.client.api.analytics
                 {
                     // Clear the set because the cache is only invalidated when there is no
                     // exception, so the targets will reappear in the next iteration
-                    logger.LogError("SDKCODE(stream:7002): Posting metrics failed, reason: {reason}", ex.Message);
+                    if (logger.IsEnabled(LogLevel.Error))
+                        logger.LogError("SDKCODE(stream:7002): Posting metrics failed, reason: {reason}", ex.Message);
                 }
         }
 

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -127,18 +127,13 @@ namespace io.harness.cfsdk.client.api.analytics
 
         public bool IsTargetSeen(string identifier)
         {
-            if (identifier == null) return false;
-
             return SeenTargetsCache.getIfPresent(identifier);
         }
 
         public void MarkTargetAsSeen(string identifier)
 
         {
-            if (SeenTargetsCache.Count() > seenTargetsCacheMaxSize)
-            {
-                return;
-            }
+            if (SeenTargetsCache.Count() > seenTargetsCacheMaxSize) return;
             SeenTargetsCache.Put(identifier);
         }
 

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -124,9 +124,11 @@ namespace io.harness.cfsdk.client.api.analytics
             
             return metrics;
         }
-        
+
         public bool IsTargetSeen(string identifier)
         {
+            if (identifier == null) return false;
+
             return SeenTargetsCache.getIfPresent(identifier);
         }
 

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -127,7 +127,7 @@ namespace io.harness.cfsdk.client.api.analytics
 
         public bool IsTargetSeen(string identifier)
         {
-            return SeenTargetsCache.getIfPresent(identifier);
+            return SeenTargetsCache.ContainsKey(identifier);
         }
 
         public void MarkTargetAsSeen(string identifier)

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -20,7 +20,10 @@ namespace io.harness.cfsdk.client.api.analytics
         private static readonly string Server = "server";
         private static readonly string SdkLanguage = "SDK_LANGUAGE";
         private static readonly string SdkVersion = "SDK_VERSION";
-        internal readonly SeenTargetsCache SeenTargets = new();
+        internal readonly SeenTargetsCache seenTargetsCache = new();
+
+        public SeenTargetsCache SeenTargetsCache => seenTargetsCache;
+
         private readonly IConnector connector;
         private readonly EvaluationAnalyticsCache evaluationAnalyticsCache;
         private readonly ILogger<AnalyticsPublisherService> logger;
@@ -121,13 +124,13 @@ namespace io.harness.cfsdk.client.api.analytics
         
         public bool IsTargetSeen(string identifier)
         {
-            return SeenTargets.getIfPresent(identifier);
+            return SeenTargetsCache.getIfPresent(identifier);
         }
 
         public void MarkTargetAsSeen(string identifier)
 
         {
-            SeenTargets.Put(identifier);
+            SeenTargetsCache.Put(identifier);
         }
 
         private void SetCommonSdkAttributes(MetricsData metricsData)

--- a/client/api/analytics/AnalyticsPublisherService.cs
+++ b/client/api/analytics/AnalyticsPublisherService.cs
@@ -137,6 +137,11 @@ namespace io.harness.cfsdk.client.api.analytics
             if (SeenTargetsCache.Count() > seenTargetsCacheMaxSize) return;
             SeenTargetsCache.Put(identifier);
         }
+        
+        public void ResetSeenTargetsCache()
+        {
+            SeenTargetsCache.resetCache();
+        }
 
         private void SetCommonSdkAttributes(MetricsData metricsData)
         {

--- a/client/cache/MyCache.cs
+++ b/client/cache/MyCache.cs
@@ -72,6 +72,16 @@ namespace io.harness.cfsdk.client.cache
                 _ = CacheMap.AddOrUpdate(key, value, (_, _) => value);
             }
         }
+        
+        // Calls TryAdd instead of AddOrUpdate for caches that don't need a value counter
+        public void PutIfAbsent(TK key, TV value)
+        {
+            if (CacheMap.TryAdd(key, value))
+            {
+                Interlocked.Increment(ref itemCount);
+            }
+        }
+
 
         public new void Delete(TK key)
         {
@@ -96,9 +106,21 @@ namespace io.harness.cfsdk.client.cache
     internal class EvaluationAnalyticsCache : MemoryCacheWithCounter<EvaluationAnalytics, int>
     {
     }
-    
-    internal class TargetAnalyticsCache : MemoryCacheWithCounter<TargetAnalytics, int>
+
+    internal class TargetAnalyticsCache : MemoryCacheWithCounter<TargetAnalytics, bool>
     {
+        public new void Put(TargetAnalytics key, bool value = true)
+        {
+            PutIfAbsent(key, value);
+        }
+    }
+
+    internal class SeenTargetsCache : MemoryCacheWithCounter<string, bool>
+    {
+        public new void Put(string key, bool value = true)
+        {
+            PutIfAbsent(key, value);
+        }
     }
 
 

--- a/client/cache/MyCache.cs
+++ b/client/cache/MyCache.cs
@@ -98,13 +98,13 @@ namespace io.harness.cfsdk.client.cache
 
         public int Count()
         {
-            return itemCount;
+            return Interlocked.CompareExchange(ref itemCount, 0, 0);
         }
 
         public new void resetCache()
         {
             CacheMap = new ConcurrentDictionary<TK, TV>();
-            itemCount = 0; 
+            Interlocked.Exchange(ref itemCount, 0); 
         }
     }
 

--- a/client/cache/MyCache.cs
+++ b/client/cache/MyCache.cs
@@ -55,6 +55,11 @@ namespace io.harness.cfsdk.client.cache
                 Put(item);
             }
         }
+        
+        public bool ContainsKey(TK key)
+        {
+            return CacheMap.ContainsKey(key);
+        }
     }
     
     internal class MemoryCacheWithCounter<TK, TV> : MemoryCache<TK, TV>

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,9 +8,9 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.0-rc1</Version>
+        <Version>1.7.0-rc.2</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.0-rc1</PackageVersion>
+        <PackageVersion>1.7.0-rc.2</PackageVersion>
         <AssemblyVersion>1.7.0</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -317,7 +317,7 @@ namespace ff_server_sdk_test.api.analytics
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
 
-            Assert.IsTrue(analyticsPublisherService.SeenTargets.ContainsKey(target1),
+            Assert.IsTrue(analyticsPublisherService.SeenTargets.getIfPresent(target1.Identifier),
                 "Target should be pushed to GlobalTargetSet");
         }
 
@@ -388,8 +388,8 @@ namespace ff_server_sdk_test.api.analytics
 
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
-            var count = analyticsPublisherService.SeenTargets.Count;
-            Assert.IsTrue(analyticsPublisherService.SeenTargets.Count == 40);
+            var count = analyticsPublisherService.SeenTargets.Count();
+            Assert.IsTrue(analyticsPublisherService.SeenTargets.Count() == 40);
         }
 
 

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -317,7 +317,7 @@ namespace ff_server_sdk_test.api.analytics
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
 
-            Assert.IsTrue(analyticsPublisherService.SeenTargets.getIfPresent(target1.Identifier),
+            Assert.IsTrue(analyticsPublisherService.SeenTargetsCache.getIfPresent(target1.Identifier),
                 "Target should be pushed to GlobalTargetSet");
         }
 
@@ -388,8 +388,8 @@ namespace ff_server_sdk_test.api.analytics
 
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
-            var count = analyticsPublisherService.SeenTargets.Count();
-            Assert.IsTrue(analyticsPublisherService.SeenTargets.Count() == 40);
+            var count = analyticsPublisherService.SeenTargetsCache.Count();
+            Assert.IsTrue(analyticsPublisherService.SeenTargetsCache.Count() == 40);
         }
 
 

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -27,8 +27,11 @@ namespace ff_server_sdk_test.api.analytics
                     targetAnalyticsCacheMock, new NullLoggerFactory(), new Config());
 
             var variation = new Variation();
-            var target = new Target();
-
+            var target = Target.builder()
+                .Identifier("identifier")
+                .Attributes(new Dictionary<string, string> { { "email", "demo@harness.io" } })
+                .build(); 
+            
             var featureConfig1 = CreateFeatureConfig("feature1");
             var evaluationAnalytics = new EvaluationAnalytics(featureConfig1, variation, target);
             var targetAnalytics = new TargetAnalytics(target);
@@ -50,7 +53,7 @@ namespace ff_server_sdk_test.api.analytics
 
             // Ensure the counter is correct.
             Assert.That(evaluationAnalyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
-            Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
+            Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(true));
         }
         
         [Test]
@@ -86,7 +89,7 @@ namespace ff_server_sdk_test.api.analytics
 
             // Ensure the counter is correct.
             Assert.That(evaluationAnalyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
-            Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(0));
+            Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(false));
         }
 
 
@@ -100,8 +103,10 @@ namespace ff_server_sdk_test.api.analytics
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
                     targetAnalyticsCacheMock, new NullLoggerFactory(), new Config());
 
-            var target = new Target();
-            var variation = new Variation();
+            var target = Target.builder()
+                .Identifier("identifier")
+                .Attributes(new Dictionary<string, string> { { "email", "demo@harness.io" } })
+                .build();             var variation = new Variation();
 
             // simulate multiple evaluations for a single feature
             var featureConfig = CreateFeatureConfig("feature1");
@@ -126,7 +131,7 @@ namespace ff_server_sdk_test.api.analytics
 
             // Correct count
             Assert.That(evaluationAnalyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(5));
-            Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
+            Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(true));
         }
 
         [Test]
@@ -140,8 +145,10 @@ namespace ff_server_sdk_test.api.analytics
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
                     targetAnalyticsCacheMock, new NullLoggerFactory(), new Config());
 
-            var target = new Target();
-            var variation = new Variation();
+            var target = Target.builder()
+                .Identifier("identifier")
+                .Attributes(new Dictionary<string, string> { { "email", "demo@harness.io" } })
+                .build();             var variation = new Variation();
 
             // simulate an evaluation for multiple different features
             var featureConfig1 = CreateFeatureConfig("feature1");
@@ -165,7 +172,7 @@ namespace ff_server_sdk_test.api.analytics
             // Ensure the counter is correct
             Assert.That(evaluationAnalyticsCacheMock.getIfPresent(evaluationAnalytics), Is.EqualTo(1));
             Assert.That(evaluationAnalyticsCacheMock.getIfPresent(evaluationAnalytics2), Is.EqualTo(1));
-            Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(1));
+            Assert.That(targetAnalyticsCacheMock.getIfPresent(targetAnalytics), Is.EqualTo(true));
         }
 
 
@@ -180,9 +187,10 @@ namespace ff_server_sdk_test.api.analytics
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
                     targetAnalyticsCacheMock, new NullLoggerFactory(), new Config());
 
-            var target = new Target();
-            // var target = new Target(EvaluationAnalytics.GlobalTargetIdentifier, EvaluationAnalytics.GlobalTargetName,
-            //     null);
+            var target = Target.builder()
+                .Identifier("identifier")
+                .Attributes(new Dictionary<string, string> { { "email", "demo@harness.io" } })
+                .build(); 
             var variation = new Variation();
 
             // simulate an evaluation for multiple different features
@@ -389,7 +397,7 @@ namespace ff_server_sdk_test.api.analytics
             // Trigger the push to GlobalTargetSet
             analyticsPublisherService.SendDataAndResetCache();
             var count = analyticsPublisherService.SeenTargetsCache.Count();
-            Assert.IsTrue(analyticsPublisherService.SeenTargetsCache.Count() == 40);
+            Assert.IsTrue(analyticsPublisherService.SeenTargetsCache.Count() == 30);
         }
 
 

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -413,7 +413,7 @@ namespace ff_server_sdk_test.api.analytics
 
             var metricsProcessor = new MetricsProcessor(config, evaluationAnalyticsCacheMock, targetAnalyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory(), false);
 
-            Parallel.For(0, 501000, i =>
+            Parallel.For(0, 51000, i =>
             {
                 var target = Target.builder()
                     .Identifier($"unique_identifier_{i}")
@@ -443,7 +443,7 @@ namespace ff_server_sdk_test.api.analytics
 
             var metricsProcessor = new MetricsProcessor(config, evaluationAnalyticsCacheMock, targetAnalyticsCacheMock, analyticsPublisherServiceMock, new NullLoggerFactory(), false);
 
-            Parallel.For(0, 501000, i =>
+            Parallel.For(0, 150000, i =>
             {
                 var target = Target.builder()
                     .Identifier($"unique_identifier_{i}")
@@ -466,6 +466,10 @@ namespace ff_server_sdk_test.api.analytics
             // The SeenTargetsCache counter is not 100% precise, so allow a small margin
             var limitMargin = 50;
             Assert.That(analyticsPublisherServiceMock.SeenTargetsCache.Count(), Is.LessThan(config.targetMetricsMaxSize + limitMargin));
+            
+            analyticsPublisherServiceMock.SeenTargetsCache.resetCache();
+            Assert.That(analyticsPublisherServiceMock.SeenTargetsCache.Count(), Is.EqualTo(0));
+
         }
 
 

--- a/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
+++ b/tests/ff-server-sdk-test/api/analytics/AnalyticsManagerTest.cs
@@ -24,7 +24,7 @@ namespace ff_server_sdk_test.api.analytics
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock =
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
-                    targetAnalyticsCacheMock, new NullLoggerFactory());
+                    targetAnalyticsCacheMock, new NullLoggerFactory(), new Config());
 
             var variation = new Variation();
             var target = new Target();
@@ -61,7 +61,7 @@ namespace ff_server_sdk_test.api.analytics
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock =
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
-                    targetAnalyticsCacheMock, new NullLoggerFactory());
+                    targetAnalyticsCacheMock, new NullLoggerFactory(), new Config());
 
             var variation = new Variation();
 
@@ -98,7 +98,7 @@ namespace ff_server_sdk_test.api.analytics
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock =
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
-                    targetAnalyticsCacheMock, new NullLoggerFactory());
+                    targetAnalyticsCacheMock, new NullLoggerFactory(), new Config());
 
             var target = new Target();
             var variation = new Variation();
@@ -138,7 +138,7 @@ namespace ff_server_sdk_test.api.analytics
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock =
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
-                    targetAnalyticsCacheMock, new NullLoggerFactory());
+                    targetAnalyticsCacheMock, new NullLoggerFactory(), new Config());
 
             var target = new Target();
             var variation = new Variation();
@@ -178,7 +178,7 @@ namespace ff_server_sdk_test.api.analytics
             var connectorMock = new Mock<IConnector>();
             var analyticsPublisherServiceMock =
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
-                    targetAnalyticsCacheMock, new NullLoggerFactory());
+                    targetAnalyticsCacheMock, new NullLoggerFactory(), new Config());
 
             var target = new Target();
             // var target = new Target(EvaluationAnalytics.GlobalTargetIdentifier, EvaluationAnalytics.GlobalTargetName,
@@ -222,7 +222,7 @@ namespace ff_server_sdk_test.api.analytics
             var loggerFactory = new NullLoggerFactory();
             var analyticsPublisherService =
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
-                    targetAnalyticsCacheMock, loggerFactory);
+                    targetAnalyticsCacheMock, loggerFactory, new Config());
 
             // Pass true for global target
             var metricsProcessor =
@@ -290,7 +290,7 @@ namespace ff_server_sdk_test.api.analytics
             var loggerFactory = new NullLoggerFactory();
             var analyticsPublisherService =
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
-                    targetAnalyticsCacheMock, loggerFactory);
+                    targetAnalyticsCacheMock, loggerFactory, new Config());
             var metricsProcessor =
                 new MetricsProcessor(new Config(), evaluationAnalyticsCacheMock, targetAnalyticsCacheMock,
                     analyticsPublisherService, loggerFactory, false);
@@ -330,7 +330,7 @@ namespace ff_server_sdk_test.api.analytics
             var loggerFactory = new NullLoggerFactory();
             var analyticsPublisherService =
                 new AnalyticsPublisherService(connectorMock.Object, evaluationAnalyticsCacheMock,
-                    targetAnalyticsCacheMock, loggerFactory);
+                    targetAnalyticsCacheMock, loggerFactory, new Config());
             var metricsProcessor =
                 new MetricsProcessor(new Config(), evaluationAnalyticsCacheMock, targetAnalyticsCacheMock,
                     analyticsPublisherService, loggerFactory, false);


### PR DESCRIPTION
# What
Applies the following optimsations to the `SeenTargetsCache` to reduce memory footprint and decrease latency

- Keys on `targetIdentifier` instead of the full `Target` which was left over when targets were equal by ID + attributes. Now they are equal based on ID along so no need to store the full target. This should significantly reduce memory
- Sets configurable limit to cache size, defaulting to 500K targets. This will prevent unbounded memory growth. 
- Configurable `SeenTargetsCache` reset, defaulting to 12 hours. 
- For checking target existence, uses `ContainsKey` instead of `TryGetValue` as no need to get the value. This should improve performance. 
- For adding targets to both `SeenTargetsCache` and `TargetAnalyticsCache`, uses `TryAdd` instead of `AddOrUpdate` as we don't need to increment a counter value. 
- No longer creates a new `Target` to represent a global target on each evaluation. Now creates a member variable to represent the global target.


# Testing
- New unit tests for cache limits
- Existing unit tests pass for correct metrics behaviour
- Manual testing with sample app


