### PR TITLE
FFM-11549 1.7.0-rc2 bump

### DIFF
--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,9 +8,9 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.0-rc.2</Version>
+        <Version>1.7.0-rc2</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.0-rc.2</PackageVersion>
+        <PackageVersion>1.7.0-rc2</PackageVersion>
         <AssemblyVersion>1.7.0</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>


### PR DESCRIPTION
# What
The first 1.7.0 RC used version `1.7.0-rc1` which was not a correct semver standard.  We have just released `1.7.0-rc.2` using correct semver versioning, and despite it being published to Nuget, is not being pulled correctly. `1.7.0-rc1` gets pulled instead.

This PR is to version it using the incorrect standard, and then we can use the correct standard for other RCs > 1.7.0

