### PR TITLE
[FFM-11585] - Sort rules when retrieving instead of per evaluation

### DIFF
--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -358,9 +358,8 @@ namespace io.harness.cfsdk.client.api
                 if (servingRules != null && servingRules.Count > 0)
                 {
                     // Use enhanced rules first if they're available
-                    var sortedServingRules = servingRules.OrderBy(r => r.Priority);
 
-                    if (sortedServingRules.Any(r => r.Clauses.Count > 0 && r.Clauses.All(c => EvaluateClause(c, target))))
+                    if (servingRules.Any(r => r.Clauses.Count > 0 && r.Clauses.All(c => EvaluateClause(c, target))))
                     {
                         return true;
                     }

--- a/client/api/Repository.cs
+++ b/client/api/Repository.cs
@@ -214,9 +214,20 @@ namespace io.harness.cfsdk.client.api
             }
         }
 
+        private void SortServingGroups(Segment segment)
+        {
+            if (segment == null || segment.ServingRules == null || segment.ServingRules.Count <= 1)
+            {
+                return;
+            }
+            // Keep the ServingRules sorted by priority, we will always short-circuit on the first true
+            segment.ServingRules = segment.ServingRules.OrderBy(r => r.Priority).ToList();
+        }
+
         void IRepository.SetSegment(string identifier, Segment segment)
         {
             rwLock.EnterWriteLock();
+            SortServingGroups(segment);
             try
             {
                 Segment current = GetSegment(identifier, false);
@@ -263,6 +274,7 @@ namespace io.harness.cfsdk.client.api
                 foreach (var item in segments)
                 {
                     CacheClauseValues(item);
+                    SortServingGroups(item);
                     Update(item.Identifier, SegmentKey(item.Identifier), item);
                 }
             }

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,9 +8,9 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.0-rc2</Version>
+        <Version>1.7.0-rc3</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.0-rc2</PackageVersion>
+        <PackageVersion>1.7.0-rc3</PackageVersion>
         <AssemblyVersion>1.7.0</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>


### PR DESCRIPTION
[FFM-11585] - Sort rules when retrieving instead of per evaluation

**What**
Move the rules sorting into `SetSegment` similar to map caching so that it is only done once.

**Why**
Avoid the cost of sorting multiple times during evaluations when it is unnecessary. Some customer are using a lot of rules and this wastes CPU.

**Testing**
Load testing + testgrid

[FFM-11585]: https://harness.atlassian.net/browse/FFM-11585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ