### PR TITLE
FFM-11573 Fix streaming issues for .NET 4.8

### DIFF
--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Target = io.harness.cfsdk.client.dto.Target;
 

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -96,13 +96,13 @@ namespace io.harness.cfsdk.client.api
                 logger.LogWarning(ex, "First poll failed: {Reason}", ex.Message);
             }
 
-            logger.LogDebug("SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}", intervalMs);
+            logger.LogInformation("SDKCODE(poll:4000): Polling started, intervalMs: {intervalMs}", intervalMs);
             // start timer which will initiate periodic reading of flags and segments
             pollTimer = new Timer(OnTimedEventAsync, null, intervalMs, intervalMs);
         }
         public void Stop()
         {
-            logger.LogDebug("SDKCODE(poll:4001): Polling stopped");
+            logger.LogInformation("SDKCODE(poll:4001): Polling stopped");
             // stop timer
             if (pollTimer == null) return;
             pollTimer.Dispose();

--- a/client/api/UpdateProcessor.cs
+++ b/client/api/UpdateProcessor.cs
@@ -87,7 +87,7 @@ namespace io.harness.cfsdk.client.api
                 catch (Exception ex)
                 {
                     retryCount++;
-                    logger.LogWarning(ex, "Failed to start the stream. Retry attempt {Attempt} in {Delay} seconds", retryCount, Math.Pow(2, retryCount) * initialDelaySeconds);
+                    logger.LogWarning(ex, "Failed to restart the stream on attempt {Attempt}. Waiting {Delay} seconds before next retry. Exception: {ExceptionMessage}", retryCount, Math.Pow(2, retryCount) * initialDelaySeconds, ex.Message);
                     
                 }
             }

--- a/client/api/UpdateProcessor.cs
+++ b/client/api/UpdateProcessor.cs
@@ -71,32 +71,11 @@ namespace io.harness.cfsdk.client.api
             this.callback.OnStreamConnected();
         }
 
-        private async Task StartAfterInterval()
-        {
-            const int initialDelaySeconds = 1;
 
-            int retryCount = 0;
-            while (true)
-            {
-                try
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, retryCount) * initialDelaySeconds));
-                    Start();
-                    break; 
-                }
-                catch (Exception ex)
-                {
-                    retryCount++;
-                    logger.LogWarning(ex, "Failed to restart the stream on attempt {Attempt}. Waiting {Delay} seconds before next retry. Exception: {ExceptionMessage}", retryCount, Math.Pow(2, retryCount) * initialDelaySeconds, ex.Message);
-                    
-                }
-            }
-        }
         public void OnStreamDisconnected()
         {
             this.callback.OnStreamDisconnected();
-            Stop();
-            _ = StartAfterInterval();
+
         }
         private async Task ProcessMessage(Message message)
         {

--- a/client/api/UpdateProcessor.cs
+++ b/client/api/UpdateProcessor.cs
@@ -73,8 +73,24 @@ namespace io.harness.cfsdk.client.api
 
         private async Task StartAfterInterval()
         {
-            await Task.Delay(TimeSpan.FromSeconds(this.config.pollIntervalInSeconds));
-            Start();
+            const int initialDelaySeconds = 1;
+
+            int retryCount = 0;
+            while (true)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, retryCount) * initialDelaySeconds));
+                    Start();
+                    break; 
+                }
+                catch (Exception ex)
+                {
+                    retryCount++;
+                    logger.LogWarning(ex, "Failed to start the stream. Retry attempt {Attempt} in {Delay} seconds", retryCount, Math.Pow(2, retryCount) * initialDelaySeconds);
+                    
+                }
+            }
         }
         public void OnStreamDisconnected()
         {

--- a/client/api/analytics/AnalyticsManager.cs
+++ b/client/api/analytics/AnalyticsManager.cs
@@ -51,7 +51,7 @@ namespace io.harness.cfsdk.client.api.analytics
                 timer.Start();
                 
                 // SeenTargetsCache timer
-                seenTargetsCacheResetTimer = new Timer(config.seenTargetsCacheTtlInSeconds);
+                seenTargetsCacheResetTimer = new Timer((long)config.seenTargetsCacheTtlInSeconds * 1000);
                 seenTargetsCacheResetTimer.Elapsed += SeenTargetsCacheResetTimer_Elapsed;
                 seenTargetsCacheResetTimer.AutoReset = true;
                 seenTargetsCacheResetTimer.Enabled = true;

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -17,11 +17,9 @@ namespace io.harness.cfsdk.client.connector
         private readonly string url;
         private readonly HttpClient httpClient;
         private readonly IUpdateCallback callback;
-        private const int InitialConnectionTimeoutMs = 10000; 
         private const int ReadTimeoutMs = 35_000;
         private const int BaseDelayMs = 200; 
         private const int MaxDelayMs = 5000; 
-
         private static readonly Random Random = new();
 
         public EventSource(HttpClient httpClient, string url, IUpdateCallback callback, ILoggerFactory loggerFactory)
@@ -73,49 +71,49 @@ namespace io.harness.cfsdk.client.connector
         {
             var retryCount = 0;
             while (true)
+            {
                 try
                 {
-                    logger.LogDebug("Starting EventSource service");
-                    using var initialRequestToken = new CancellationTokenSource(InitialConnectionTimeoutMs);
-                    var request = new HttpRequestMessage(HttpMethod.Get, url);
-                    var response =
-                    await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, initialRequestToken.Token);
-                    response.EnsureSuccessStatusCode();
-                    using var stream = await response.Content.ReadAsStreamAsync();
-                    retryCount = 0;
-                    callback.OnStreamConnected();
+                    Debug.Assert(httpClient != null);
 
-                    string message;
-                    while ((message = ReadLine(stream, ReadTimeoutMs)) != null)
+                    logger.LogDebug("Starting EventSource service.");
+                    using (Stream stream = await this.httpClient.GetStreamAsync(url))
                     {
-                        if (!message.Contains("domain"))
+                        retryCount = 0;
+                        callback.OnStreamConnected();
+
+                        string message;
+                        while ((message = ReadLine(stream, ReadTimeoutMs)) != null)
                         {
-                            logger.LogTrace("Received event source heartbeat");
-                            continue;
+                            if (!message.Contains("domain"))
+                            {
+                                logger.LogTrace("Received event source heartbeat");
+                                continue;
+                            }
+
+                            logger.LogInformation("SDKCODE(stream:5002): SSE event received {message}", message);
+
+                            // parse message
+                            var jsonMessage = JObject.Parse("{" + message + "}");
+                            var data = jsonMessage["data"];
+                            var msg = new Message
+                            {
+                                Domain = (string)data["domain"],
+                                Event = (string)data["event"],
+                                Identifier = (string)data["identifier"],
+                                Version = long.Parse((string)data["version"])
+                            };
+
+                            callback.Update(msg, false);
                         }
-
-                        logger.LogInformation("SDKCODE(stream:5002): SSE event received {message}",
-                            message);
-
-                        // parse message
-                        var jsonMessage = JObject.Parse("{" + message + "}");
-                        var data = jsonMessage["data"];
-                        var msg = new Message
-                        {
-                            Domain = (string)data["domain"],
-                            Event = (string)data["event"],
-                            Identifier = (string)data["identifier"],
-                            Version = long.Parse((string)data["version"])
-                        };
-
-                        callback.Update(msg, false);
                     }
+
                 }
                 catch (Exception e)
                 {
                     retryCount++;
 
-                    var delay = Math.Min(BaseDelayMs * (int)Math.Pow(2, retryCount), MaxDelayMs);
+                    int delay = Math.Min(BaseDelayMs * (int)Math.Pow(2, retryCount), MaxDelayMs);
                     var jitter = Random.Next(0, BaseDelayMs);
                     delay += jitter;
 
@@ -129,6 +127,7 @@ namespace io.harness.cfsdk.client.connector
                 {
                     callback.OnStreamDisconnected();
                 }
+            }
         }
     }
 }

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -15,7 +15,6 @@ namespace io.harness.cfsdk.client.connector
     {
         private readonly ILogger<EventSource> logger;
         private readonly string url;
-        private readonly Config config;
         private readonly HttpClient httpClient;
         private readonly IUpdateCallback callback;
         private const int ReadTimeoutMs = 35_000;
@@ -23,11 +22,10 @@ namespace io.harness.cfsdk.client.connector
         private const int MaxDelayMs = 5000; 
         private static readonly Random Random = new();
 
-        public EventSource(HttpClient httpClient, string url, Config config, IUpdateCallback callback, ILoggerFactory loggerFactory)
+        public EventSource(HttpClient httpClient, string url, IUpdateCallback callback, ILoggerFactory loggerFactory)
         {
             this.httpClient = httpClient;
             this.url = url;
-            this.config = config;
             this.callback = callback;
             this.logger = loggerFactory.CreateLogger<EventSource>();
         }

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -125,7 +125,6 @@ namespace io.harness.cfsdk.client.connector
                     logger.LogError(e,
                         "EventSource service threw an error: {Reason}. Retrying in {Delay} seconds",
                         e.Message, delay / 1000.0);
-                    Debug.WriteLine(e.ToString());
                     await Task.Delay(delay);
                 }
                 finally

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -110,7 +110,6 @@ namespace io.harness.cfsdk.client.connector
             }
             finally
             {
-                Thread.Sleep(TimeSpan.FromSeconds(10));
                 callback.OnStreamDisconnected();
             }
 

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -113,9 +113,7 @@ namespace io.harness.cfsdk.client.connector
                 {
                     retryCount++;
 
-                    // Calculate the delay with exponential backoff
                     int delay = Math.Min(BaseDelayMs * (int)Math.Pow(2, retryCount), MaxDelayMs);
-                    // Introduce jitter by adding a random amount of time, and ensure it doesn't exceed MaxDelayMs
                     var jitter = Random.Next(0, BaseDelayMs);
                     delay += jitter;
 

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -18,7 +18,7 @@ namespace io.harness.cfsdk.client.connector
         private readonly Config config;
         private readonly HttpClient httpClient;
         private readonly IUpdateCallback callback;
-        private const int ReadTimeoutMs = 60_000;
+        private const int ReadTimeoutMs = 35_000;
         private const int BaseDelayMs = 200; 
         private const int MaxDelayMs = 5000; 
         private static readonly Random random = new Random();

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -21,7 +21,7 @@ namespace io.harness.cfsdk.client.connector
         private const int ReadTimeoutMs = 35_000;
         private const int BaseDelayMs = 200; 
         private const int MaxDelayMs = 5000; 
-        private static readonly Random random = new Random();
+        private static readonly Random Random = new();
 
         public EventSource(HttpClient httpClient, string url, Config config, IUpdateCallback callback, ILoggerFactory loggerFactory)
         {
@@ -118,7 +118,7 @@ namespace io.harness.cfsdk.client.connector
                     // Calculate the delay with exponential backoff
                     int delay = Math.Min(BaseDelayMs * (int)Math.Pow(2, retryCount), MaxDelayMs);
                     // Introduce jitter by adding a random amount of time, and ensure it doesn't exceed MaxDelayMs
-                    var jitter = random.Next(0, BaseDelayMs);
+                    var jitter = Random.Next(0, BaseDelayMs);
                     delay += jitter;
 
 

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -79,6 +79,9 @@ namespace io.harness.cfsdk.client.connector
 
                     logger.LogDebug("Starting EventSource service");
                     
+                    // In .NET 4.8, we can't use a traditional HTTP Client timeout, or cacncellation token, 
+                    // as the HTTP client interprets reading from the stream as the connection is still open. 
+                    // We use this workaround instead to simulate a timeout for the initial request.
                     var initialTask = Task.Run(async () =>
                     {
                         await Task.Delay(InitialConnectionTimeoutMs);
@@ -96,7 +99,7 @@ namespace io.harness.cfsdk.client.connector
 
                     if (completedTask == initialTask)
                     {
-                        await initialTask; // This will throw the timeout exception
+                        await initialTask; 
                     }
                     
                     using (Stream stream = await this.httpClient.GetStreamAsync(url))

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -281,7 +281,7 @@ namespace io.harness.cfsdk.client.connector
         {
             currentStream?.Close();
             var url = $"stream?cluster={cluster}";
-            currentStream = new EventSource(sseHttpClient, url, config, updater, loggerFactory);
+            currentStream = new EventSource(sseHttpClient, url, updater, loggerFactory);
             return currentStream;
         }
         public async Task PostMetrics(HarnessOpenMetricsAPIService.Metrics metrics)

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -160,6 +160,10 @@ namespace io.harness.cfsdk.client.connector
         private static HttpClient SseHttpClient(Config config, string apiKey, ILoggerFactory loggerFactory)
         {
             HttpClient client = CreateHttpClientWithTls(config, loggerFactory);
+            // Don't rely on the http client timeout to kill dead streams, as behaviour can be different
+            // depending on the .NET version.  Instead, we use custom logic to kill a stream if a heartbeat hasn't
+            // been received in a given period. 
+            client.Timeout = Timeout.InfiniteTimeSpan;;
             client.BaseAddress = new Uri(config.ConfigUrl.EndsWith("/") ? config.ConfigUrl : config.ConfigUrl + "/" );
             client.DefaultRequestHeaders.Add("API-Key", apiKey);
             client.DefaultRequestHeaders.Add("Accept", "text /event-stream");
@@ -169,7 +173,6 @@ namespace io.harness.cfsdk.client.connector
             {
                 client.DefaultRequestHeaders.Add("Harness-AccountID", _accountId);
             }
-            client.Timeout = TimeSpan.FromMinutes(1);
             return client;
         }
         

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -56,7 +56,7 @@ namespace io.harness.cfsdk.client.connector
                 return new HttpClient();
             }
 
-#if (NETSTANDARD || NET461)
+#if (NETSTANDARD || NET461 || NET48)
             throw new NotSupportedException("Custom TLS certificates require .net5.0 target or greater");
 #else
             var logger = loggerFactory.CreateLogger<HarnessConnector>();

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <!-- The SDK must be built with .NET 7 however we must also keep compatibility with .NET 5/6 hence SupportedOSPlatformVersion=9 below -->
-        <TargetFrameworks>netstandard2.0;net461;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net461;net48;net5.0;net6.0;net7.0</TargetFrameworks>
         <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
         <LangVersion>9.0</LangVersion>
         <PackageId>ff-dotnet-server-sdk</PackageId>

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.0-rc3</Version>
+        <Version>1.6.10</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.0-rc3</PackageVersion>
-        <AssemblyVersion>1.7.0</AssemblyVersion>
+        <PackageVersion>1.6.10</PackageVersion>
+        <AssemblyVersion>1.6.10</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
@@ -39,7 +39,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48'" />
         <PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/tests/ff-server-sdk-test/connector/EventSourceTest.cs
+++ b/tests/ff-server-sdk-test/connector/EventSourceTest.cs
@@ -84,7 +84,7 @@ namespace ff_server_sdk_test.connector
             var callback = new TestCallback();
             Config config = new ConfigBuilder().ConfigUrl(server.Url + "/api/1.0").Build();
             var httpClient = SseHttpClient(config, "dummyapikey");
-            var eventSource = new EventSource(httpClient, "stream", config, callback, new NullLoggerFactory());
+            var eventSource = new EventSource(httpClient, "stream", callback, new NullLoggerFactory());
             eventSource.Start();
 
             callback.WaitForDisconnect();
@@ -125,7 +125,7 @@ namespace ff_server_sdk_test.connector
             var callback = new TestCallback();
             Config config = new ConfigBuilder().ConfigUrl(server.Url + "/api/1.0").Build();
             var httpClient = SseHttpClient(config, "dummyapikey");
-            var eventSource = new EventSource(httpClient, "stream", config, callback, new NullLoggerFactory());
+            var eventSource = new EventSource(httpClient, "stream", callback, new NullLoggerFactory());
             eventSource.Start();
 
             callback.WaitForDisconnect();


### PR DESCRIPTION
# What
On .NET 4.8, the stream was disconnecting after about one minute.  This was caused by the http client used in that version timing out despite it being a long lived streaming connection - this does not happen on newer .NET versions with different http client behaviour.  The stream was taking at least 70 seconds to reconnect depending on the polling interval used.

- This fix sets the SSE http client's timeout to `Infinity` and uses the heartbeat mechanism to kill any "dead" streams.  If a heartbeat isn't received in 35 seconds, the stream will abort and reconnect.  
- If the initial request doesn't resolve within 10 seconds, the stream will retry the connection. 
- Fixes the reconnection behaviour. Before, we would wait a fixed 130 seconds before attempting to reconnect which is excessively long.  Now, a backoff/delay/jitter algorithm is used with base delay of 500ms. 
- Adds `net48` to the TFM to ensure the SDK builds correct for .NET 4.8 users, and supplies the System.Net.Http import for it conditionally. 

# Testing
Manua on .NET 4.8 and .NET 7.0:
- Long running SSE connection test : The stream remained open for over 4 hours. 
- Simulating disconnections:
    -  stopped heartbeats using a local build of FF-Server - stream is killed at 35 seconds and reconnects successfully. 
    - simulated network failures using a local proxy tool - the stream reconnects successfully. 