### PR TITLE
FFM-11548 Add new `jsonVariationToken` method and deprecate `jsonVariation`

### DIFF
--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -21,7 +21,7 @@ namespace io.harness.cfsdk.client.api
         bool boolVariation(string key, dto.Target target, bool defaultValue);
         string stringVariation(string key, dto.Target target, string defaultValue);
         double numberVariation(string key, dto.Target target, double defaultValue);
-        JObject jsonVariation(string key, dto.Target target, JObject defaultValue);
+        JToken jsonVariation(string key, dto.Target target, JToken defaultValue);
 
         event EventHandler InitializationCompleted;
         event EventHandler<string> EvaluationChanged;
@@ -210,7 +210,8 @@ namespace io.harness.cfsdk.client.api
         public bool boolVariation(string key, dto.Target target, bool defaultValue) { return client.BoolVariation(key, target, defaultValue);  }
         public string stringVariation(string key, dto.Target target, string defaultValue) { return client.StringVariation(key, target, defaultValue); }
         public double numberVariation(string key, dto.Target target, double defaultValue) { return client.NumberVariation(key, target, defaultValue); }
-        public JObject jsonVariation(string key, dto.Target target, JObject defaultValue) {  return client.JsonVariation(key, target, defaultValue); }
+        public JToken jsonVariation(string key, dto.Target target, JToken defaultValue) {  return client.JsonVariation(key, target, defaultValue); }
+        
 
         // force message
         public void Update(Message msg) { client.Update(msg, true);  }

--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -21,7 +21,9 @@ namespace io.harness.cfsdk.client.api
         bool boolVariation(string key, dto.Target target, bool defaultValue);
         string stringVariation(string key, dto.Target target, string defaultValue);
         double numberVariation(string key, dto.Target target, double defaultValue);
-        JToken jsonVariation(string key, dto.Target target, JToken defaultValue);
+        JToken jsonVariationToken(string key, dto.Target target, JToken defaultValue);
+        JObject jsonVariation(string key, dto.Target target, JObject defaultValue);
+
 
         event EventHandler InitializationCompleted;
         event EventHandler<string> EvaluationChanged;
@@ -210,7 +212,10 @@ namespace io.harness.cfsdk.client.api
         public bool boolVariation(string key, dto.Target target, bool defaultValue) { return client.BoolVariation(key, target, defaultValue);  }
         public string stringVariation(string key, dto.Target target, string defaultValue) { return client.StringVariation(key, target, defaultValue); }
         public double numberVariation(string key, dto.Target target, double defaultValue) { return client.NumberVariation(key, target, defaultValue); }
-        public JToken jsonVariation(string key, dto.Target target, JToken defaultValue) {  return client.JsonVariation(key, target, defaultValue); }
+        public JToken jsonVariationToken(string key, dto.Target target, JToken defaultValue) {  return client.JsonVariationToken(key, target, defaultValue); }
+        [Obsolete("This method only supports JSON objects. If a JSON array variation is returned it will result in a warning being logged and the default variation being returned. Use jsonVariationToken(string key, Target target, JToken defaultValue) since version 1.7.0 for support of both JSON objects and arrays.")]
+        public JObject jsonVariation(string key, dto.Target target, JObject defaultValue) {  return client.JsonVariation(key, target, defaultValue); }
+
 
         // force message
         public void Update(Message msg) { client.Update(msg, true);  }

--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -211,7 +211,6 @@ namespace io.harness.cfsdk.client.api
         public string stringVariation(string key, dto.Target target, string defaultValue) { return client.StringVariation(key, target, defaultValue); }
         public double numberVariation(string key, dto.Target target, double defaultValue) { return client.NumberVariation(key, target, defaultValue); }
         public JToken jsonVariation(string key, dto.Target target, JToken defaultValue) {  return client.JsonVariation(key, target, defaultValue); }
-        
 
         // force message
         public void Update(Message msg) { client.Update(msg, true);  }

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -60,7 +60,6 @@ namespace io.harness.cfsdk.client.api
             LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
             return defaultValue;
         }
-        
         public JToken JsonVariation(string key, Target target, JToken defaultValue)
         {
             var variation = EvaluateVariation(key, target, FeatureConfigKind.Json);

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -72,7 +72,7 @@ namespace io.harness.cfsdk.client.api
                 catch (JsonReaderException ex)
                 {
                     logger.LogWarning("Failed to parse JSON variation");
-                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, ex.Message);
+                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                 }
             }
 

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -93,7 +93,7 @@ namespace io.harness.cfsdk.client.api
                     if (token.Type == JTokenType.Object) return (JObject)token;
                     if (logger.IsEnabled(LogLevel.Warning))
                     {
-                        logger.LogWarning("JSON variation is not an object. Returning default value. Use JsonVariation(string key, Target target, JToken defaultValue) which is available since version 1.7.0");
+                        logger.LogWarning("JSON variation is not an object. Returning default value. Use JsonVariationToken(string key, Target target, JToken defaultValue) which is available since version 1.7.0");
                         LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                     }
                     return defaultValue;

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -337,8 +337,7 @@ namespace io.harness.cfsdk.client.api
             }
         }
 
-
-        public JObject JsonVariation(string key, Target target, JObject defaultValue)
+        public JToken JsonVariation(string key, Target target, JToken defaultValue)
         {
             try
             {

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,9 +8,9 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.0-rc3</Version>
+        <Version>1.7.0</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.0-rc3</PackageVersion>
+        <PackageVersion>1.7.0</PackageVersion>
         <AssemblyVersion>1.7.0</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>

--- a/tests/ff-server-sdk-test/EvaluatorTest.cs
+++ b/tests/ff-server-sdk-test/EvaluatorTest.cs
@@ -161,6 +161,7 @@ namespace ff_server_sdk_test
             }
 
             object got = null;
+            object gotJsonTokenMethod = null;
             
             switch (kind)
             {
@@ -175,6 +176,7 @@ namespace ff_server_sdk_test
                     break;
                 case FeatureConfigKind.Json:
                     got = evaluator.JsonVariation(featureFlag, target, JObject.Parse("{val: 'default value'}"));
+                    gotJsonTokenMethod = evaluator.JsonVariationToken(featureFlag, target, JObject.Parse("{val: 'default value'}"));
                     break;
             }
 
@@ -188,6 +190,7 @@ namespace ff_server_sdk_test
             {
                 var expectedJson = JObject.Parse((string)expected);
                 Assert.AreEqual(expectedJson, got, $"Expected result for {featureFlag} was {expected}");
+                Assert.AreEqual(expectedJson, gotJsonTokenMethod, $"Expected result for {featureFlag} was {expected}");
             }
             else
             {


### PR DESCRIPTION
# What
This PR adds a new method `jsonVariationToken` which returns a `JToken` instead of `JObject`.   `jsonVariation` method has been marked as `Obsolete`.  

Also adds exception handling to `jsonVariation` to fix a crash if anything other than a JSON object was returned for a flag variation.

# Why
- Allows the SDK to accept `JObject/JArray/JValue` types.  
- This change allows all JSON variation types to be parsed as a `JToken` and returned to the user.  The user simply needs to use `JToken.DeepEquals` for comparisons.

# Testing
JSON objects: Call new method in ff-testcases and testgrid.
JSON arrays:  manual testing using prod 2 account with flag and json array variation.  TestGrid doesn't currently support JSON arrays.
