### PR TITLE
fix: [FFM-11759]: fix incorrect number variation warning message

### DIFF
--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -75,7 +75,7 @@ namespace io.harness.cfsdk.client.api
             double res;
             if (variation != null && double.TryParse(variation.Value, out res)) return res;
 
-            LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue.ToString());
+            LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
             return defaultValue;
         }
 


### PR DESCRIPTION
**Issue**
NumberVariation incorrectly logged the warning as `SDKCODE(eval:6001): Failed to evaluate String variation` when it failed, rather than Int variation like elsewhere in the code