### PR TITLE
FFM-11759 Add `FlagsLoaded` Event + Unblock WaitForInit call on auth failures

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,19 +52,14 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-        
-#    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-#    # If this step fails, then you should remove it and run the build manually (see below)
-#    - name: Autobuild
-#      uses: github/codeql-action/autobuild@v2
-
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
     #   If the Autobuild fails above, remove it and uncomment the following three lines. 
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    - run: |
+    - name: Build and test SDK
+      run: |
         echo "Run, Build Application using script"
         ./build.sh
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,10 +53,10 @@ jobs:
         # queries: security-extended,security-and-quality
 
         
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+#    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+#    # If this step fails, then you should remove it and run the build manually (see below)
+#    - name: Autobuild
+#      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -64,9 +64,9 @@ jobs:
     #   If the Autobuild fails above, remove it and uncomment the following three lines. 
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+    - run: |
+        echo "Run, Build Application using script"
+        ./build.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/build.sh
+++ b/build.sh
@@ -16,14 +16,21 @@ dotnet tool install --global coverlet.console --version 3.2.0
 dotnet tool install --global dotnet-reportgenerator-globaltool
 dotnet tool restore
 
-# Install Libraries needed for build and buld
+# Install Libraries needed for build and build
 dotnet restore ff-netF48-server-sdk.csproj
 dotnet build ff-netF48-server-sdk.csproj --no-restore
-
 
 # Run tests
 echo "Generating Test Report"
 export MSBUILDDISABLENODEREUSE=1
 dotnet test tests/ff-server-sdk-test/ff-server-sdk-test.csproj -v=n --blame-hang --logger:"junit;LogFilePath=junit.xml" -nodereuse:false
+
+# Capture exit code of the test command
+TEST_EXIT_CODE=$?
+if [ "$TEST_EXIT_CODE" -ne 0 ]; then
+  echo "Tests failed. Aborting build."
+  exit $TEST_EXIT_CODE
+fi
+
 ls -l
 echo "Done"

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 echo ".NET version installed:"
 dotnet --version
 
+git submodule update --init --recursive
+
 DOTNET_VERSION=$(dotnet --version | cut -d. -f1)
 if [ "$DOTNET_VERSION" -lt 7 ]; then
 	echo "FF .NET SDK requires .NET 7 or later to build. Aborting"

--- a/client/api/AuthService.cs
+++ b/client/api/AuthService.cs
@@ -65,6 +65,12 @@ namespace io.harness.cfsdk.client.api
                 Stop();
                 logger.LogDebug("Stopping authentication service");
             }
+            catch (CfClientUnrecoverableException ex)
+            {
+                logger.LogError(ex.Message);
+                Stop();
+            }
+
             catch (Exception ex)
             {
                 // Exception thrown on Authentication. Timer will retry authentication.

--- a/client/api/AuthService.cs
+++ b/client/api/AuthService.cs
@@ -8,6 +8,7 @@ namespace io.harness.cfsdk.client.api
     interface IAuthCallback
     {
         void OnAuthenticationSuccess();
+        void OnAuthenticationFailure();
     }
     interface IAuthService
     {
@@ -69,6 +70,7 @@ namespace io.harness.cfsdk.client.api
             {
                 logger.LogError(ex.Message);
                 Stop();
+                callback.OnAuthenticationFailure();
             }
 
             catch (Exception ex)
@@ -76,8 +78,11 @@ namespace io.harness.cfsdk.client.api
                 // Exception thrown on Authentication. Timer will retry authentication.
                 if (retries++ >= config.MaxAuthRetries)
                 {
-                    logger.LogError(ex, "SDKCODE(auth:2001): Authentication failed. Max authentication retries reached {retries} - defaults will be served", retries);
+                    logger.LogError(ex,
+                        "SDKCODE(auth:2001): Authentication failed. Max authentication retries reached {retries} - defaults will be served",
+                        retries);
                     Stop();
+                    callback.OnAuthenticationFailure();
                 }
                 else
                 {

--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -67,7 +67,7 @@ namespace io.harness.cfsdk.client.api
             remove { client.EvaluationChanged -= value; }
         }
         
-        public event EventHandler<List<string>> FlagsLoaded
+        public event EventHandler<IList<string>> FlagsLoaded
         {
             add { client.FlagsLoaded += value; }
             remove { client.FlagsLoaded -= value; }

--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -1,6 +1,7 @@
 ﻿using io.harness.cfsdk.client.connector;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -64,6 +65,12 @@ namespace io.harness.cfsdk.client.api
         {
             add { client.EvaluationChanged += value; }
             remove { client.EvaluationChanged -= value; }
+        }
+        
+        public event EventHandler<List<string>> FlagsLoaded
+        {
+            add { client.FlagsLoaded += value; }
+            remove { client.FlagsLoaded -= value; }
         }
 
         // alternative client creation

--- a/client/api/CfClientException.cs
+++ b/client/api/CfClientException.cs
@@ -13,4 +13,16 @@ namespace io.harness.cfsdk.client.api
         {
         }
     }
+    
+    public class CfClientUnrecoverableException : Exception
+    {
+        public CfClientUnrecoverableException(string  errorMessage) : base(errorMessage)
+        {
+          
+        }
+
+        public CfClientUnrecoverableException(string  errorMessage, Exception innerException) : base(errorMessage, innerException)
+        {
+        }
+    }
 }

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -59,7 +59,7 @@ namespace io.harness.cfsdk.client.api
             bool res;
             if (variation != null && bool.TryParse(variation.Value, out res)) return res;
 
-            LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
+            LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue);
             return defaultValue;
         }
 
@@ -68,7 +68,7 @@ namespace io.harness.cfsdk.client.api
             var variation = EvaluateVariation(key, target, FeatureConfigKind.Json);
             if (variation == null)
             {
-                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
+                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue);
                 return defaultValue;
             }
             
@@ -80,7 +80,7 @@ namespace io.harness.cfsdk.client.api
             {
                 if (!logger.IsEnabled(LogLevel.Warning)) return defaultValue;
 
-                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
+                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue);
                 return defaultValue;
             }
 
@@ -99,7 +99,7 @@ namespace io.harness.cfsdk.client.api
                     if (!logger.IsEnabled(LogLevel.Warning)) return defaultValue;
                     
                     logger.LogWarning("JSON variation is not an object. Returning default value. Use JsonVariationToken(string key, Target target, JToken defaultValue) which is available since version 1.7.0");
-                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
+                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue);
                     return defaultValue;
                 }
                 catch (JsonReaderException ex)
@@ -110,7 +110,7 @@ namespace io.harness.cfsdk.client.api
                 }
             }
 
-            LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
+            LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue);
             return defaultValue;
         }
 
@@ -120,7 +120,7 @@ namespace io.harness.cfsdk.client.api
             double res;
             if (variation != null && double.TryParse(variation.Value, out res)) return res;
 
-            LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
+            LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue);
             return defaultValue;
         }
 
@@ -187,13 +187,14 @@ namespace io.harness.cfsdk.client.api
             return var;
         }
 
-        private void LogEvaluationFailureError(FeatureConfigKind kind, string featureKey, Target target,
-            string defaultValue)
+        private void LogEvaluationFailureError<T>(FeatureConfigKind kind, string featureKey, Target target, T defaultValue)
         {
             if (logger.IsEnabled(LogLevel.Warning))
+            {
                 logger.LogWarning(
                     "SDKCODE(eval:6001): Failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId} and the default variation {DefaultValue} is being returned",
-                    kind, target?.Identifier ?? "null target", featureKey, defaultValue);
+                    kind, target?.Identifier ?? "null target", featureKey, defaultValue?.ToString() ?? "null");
+            }
         }
 
         private bool CheckPreRequisite(FeatureConfig parentFeatureConfig, Target target)

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -253,65 +253,50 @@ namespace io.harness.cfsdk.client.api
 
         public bool BoolVariation(string key, Target target, bool defaultValue)
         {
+            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.Boolean, key, target, defaultValue);
+
             try
             {
-                if (SdkInitialized) return evaluator.BoolVariation(key, target, defaultValue);
-
-                logger.LogWarning(
-                    "SDK not initialized, returning default variation for {Flag}", key);
-                LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
-                return defaultValue;
+                return evaluator.BoolVariation(key, target, defaultValue);
             }
-
             catch (InvalidCacheStateException ex)
             {
                 logger.LogWarning(ex,
                     "Invalid cache state detected when evaluating boolean variation for flag {Key}, refreshing cache and retrying evaluation ",
                     key);
 
-                // Attempt to refresh cache
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromMilliseconds(2000));
 
-                // If the refresh has failed or exceeded the timout, return default variation
                 if (result != RefreshOutcome.Success)
                 {
                     logger.LogError(ex,
                         "Refreshing cache for boolean variation for flag {Key} failed, returning default variation ",
                         key);
-
-                    LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
-                    return defaultValue;
+                    return LogAndReturnDefault(FeatureConfigKind.Boolean, key, target, defaultValue);
                 }
 
                 try
                 {
                     return evaluator.BoolVariation(key, target, defaultValue);
                 }
-                
                 catch (InvalidCacheStateException)
                 {
                     logger.LogWarning(
-                        "SDK not initialized, returning default variation for {Flag}", key);
-
-                    LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
-                    return defaultValue;
+                        "Attempted re-evaluation of boolean variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                        key);
+                    return LogAndReturnDefault(FeatureConfigKind.Boolean, key, target, defaultValue);
                 }
             }
         }
 
         public string StringVariation(string key, Target target, string defaultValue)
         {
+            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.String, key, target, defaultValue);
+
             try
             {
-                if (SdkInitialized) return evaluator.StringVariation(key, target, defaultValue);
-
-                logger.LogWarning(
-                    "SDK not initialized, returning default variation for {Flag}", key);
-                
-                LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
-                return defaultValue;
+                return evaluator.StringVariation(key, target, defaultValue);
             }
-            
             catch (InvalidCacheStateException ex)
             {
                 logger.LogWarning(ex,
@@ -324,40 +309,31 @@ namespace io.harness.cfsdk.client.api
                     logger.LogError(
                         "Refreshing cache for string variation for flag {Key} failed, returning default variation",
                         key);
-                    LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
-                    return defaultValue;
+                    return LogAndReturnDefault(FeatureConfigKind.String, key, target, defaultValue);
                 }
 
                 try
                 {
                     return evaluator.StringVariation(key, target, defaultValue);
                 }
-                
                 catch (InvalidCacheStateException)
                 {
                     logger.LogWarning(
                         "Attempted re-evaluation of string variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
                         key);
-                    LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
-                    return defaultValue;
+                    return LogAndReturnDefault(FeatureConfigKind.String, key, target, defaultValue);
                 }
             }
         }
 
-
         public double NumberVariation(string key, Target target, double defaultValue)
         {
+            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.Int, key, target, defaultValue);
+
             try
             {
-                if (SdkInitialized) return evaluator.NumberVariation(key, target, defaultValue);
-
-                logger.LogWarning(
-                    "SDK not initialized, returning default variation for {Flag}", key);
-                
-                LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
-                return defaultValue;
+                return evaluator.NumberVariation(key, target, defaultValue);
             }
-            
             catch (InvalidCacheStateException ex)
             {
                 logger.LogWarning(ex,
@@ -369,40 +345,31 @@ namespace io.harness.cfsdk.client.api
                     logger.LogError(
                         "Refreshing cache for number variation for flag {Key} failed, returning default variation",
                         key);
-
-                    LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
-                    return defaultValue;
+                    return LogAndReturnDefault(FeatureConfigKind.Int, key, target, defaultValue);
                 }
 
                 try
                 {
                     return evaluator.NumberVariation(key, target, defaultValue);
                 }
-                
                 catch (InvalidCacheStateException)
                 {
                     logger.LogWarning(
                         "Attempted re-evaluation of number variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
                         key);
-                    LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
-                    return defaultValue;
+                    return LogAndReturnDefault(FeatureConfigKind.Int, key, target, defaultValue);
                 }
             }
         }
 
         public JToken JsonVariationToken(string key, Target target, JToken defaultValue)
         {
+            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
+
             try
             {
-                if (SdkInitialized) return evaluator.JsonVariationToken(key, target, defaultValue);
-
-                logger.LogWarning(
-                    "SDK not initialized, returning default variation for {Flag}", key);
-                
-                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
-                return defaultValue;
+                return evaluator.JsonVariationToken(key, target, defaultValue);
             }
-            
             catch (InvalidCacheStateException ex)
             {
                 logger.LogWarning(ex,
@@ -414,38 +381,30 @@ namespace io.harness.cfsdk.client.api
                     logger.LogError(
                         "Refreshing cache for json variation for flag {Key} failed, returning default variation",
                         key);
-                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
-                    return defaultValue;
+                    return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
                 }
 
                 try
                 {
                     return evaluator.JsonVariationToken(key, target, defaultValue);
                 }
-
                 catch (InvalidCacheStateException)
                 {
                     logger.LogWarning(
                         "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
                         key);
-                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
-                    return defaultValue;
+                    return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
                 }
             }
         }
-        
 
         public JObject JsonVariation(string key, Target target, JObject defaultValue)
         {
+            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
+
             try
             {
-                if (SdkInitialized) return evaluator.JsonVariation(key, target, defaultValue);
-
-                logger.LogWarning(
-                    "SDK not initialized, returning default variation for {Flag}", key);
-                
-                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
-                return defaultValue;
+                return evaluator.JsonVariation(key, target, defaultValue);
             }
             catch (InvalidCacheStateException ex)
             {
@@ -458,8 +417,7 @@ namespace io.harness.cfsdk.client.api
                     logger.LogError(
                         "Refreshing cache for json variation for flag {Key} failed, returning default variation",
                         key);
-                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
-                    return defaultValue;
+                    return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
                 }
 
                 try
@@ -471,11 +429,11 @@ namespace io.harness.cfsdk.client.api
                     logger.LogWarning(
                         "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
                         key);
-                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
-                    return defaultValue;
+                    return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
                 }
             }
         }
+
 
         public void Close()
         {
@@ -497,6 +455,16 @@ namespace io.harness.cfsdk.client.api
         {
             this.metric.PushToCache(target, featureConfig, variation);
         }
+        
+        private T LogAndReturnDefault<T>(FeatureConfigKind kind, string key, Target target, T defaultValue)
+        {
+            logger.LogWarning(
+                "SDK not initialized or failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId}. Returning default variation {DefaultValue}", 
+                kind, target?.Identifier ?? "null target", key, defaultValue);
+            LogEvaluationFailureError(kind, key, target, defaultValue.ToString());
+            return defaultValue;
+        }
+
         
         public void LogEvaluationFailureError(FeatureConfigKind kind, string featureKey, dto.Target target,
             string defaultValue)

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -193,9 +193,7 @@ namespace io.harness.cfsdk.client.api
         
         public void OnFlagsLoaded(string[] identifiers)
         {
-            // TODO implement me
-            // OnNotifyEvaluationChanged(identifier);
-            
+            OnNotifyFlagsLoaded(identifiers);
         }
         
         public void OnFlagDeleted(string identifier)

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -42,11 +42,6 @@ namespace io.harness.cfsdk.client.api
         private readonly CfClient parent;
         private readonly CountdownEvent sdkReadyLatch = new(1);
         
-        // Use property SdkInitialized for thread safe access 
-        // private int sdkInitialized; 
-        // public bool SdkInitialized => Interlocked.CompareExchange(ref sdkInitialized, 0, 0) == 1;
-        // private void SdkInitialized(bool value) => Interlocked.Exchange(ref sdkInitialized, value ? 1 : 0);
-        //
         // Use property SdkInitialized for thread-safe access 
         private int sdkInitialized; 
     

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -37,7 +37,7 @@ namespace io.harness.cfsdk.client.api
 
         public event EventHandler InitializationCompleted;
         public event EventHandler<string> EvaluationChanged;
-        public event EventHandler<List<string>> FlagsLoaded;
+        public event EventHandler<IList<string>> FlagsLoaded;
 
         private readonly CfClient parent;
         private readonly CountdownEvent sdkReadyLatch = new(1);
@@ -186,7 +186,7 @@ namespace io.harness.cfsdk.client.api
 
         }
 
-        public void OnPollCompleted(List<string> identifiers)
+        public void OnPollCompleted(IList<string> identifiers)
         {
             OnNotifyFlagsLoaded(identifiers);
         }
@@ -200,7 +200,7 @@ namespace io.harness.cfsdk.client.api
             OnNotifyEvaluationChanged(identifier);
         }
 
-        public void OnFlagsLoaded(List<string> identifiers)
+        public void OnFlagsLoaded(IList<string> identifiers)
         {
             OnNotifyFlagsLoaded(identifiers);
         }
@@ -234,7 +234,7 @@ namespace io.harness.cfsdk.client.api
             EvaluationChanged?.Invoke(parent, identifier);
         }
         
-        private void OnNotifyFlagsLoaded(List<string> identifiers)
+        private void OnNotifyFlagsLoaded(IList<string> identifiers)
         {
             FlagsLoaded?.Invoke(parent, identifiers);
         }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -195,7 +195,8 @@ namespace io.harness.cfsdk.client.api
 
         }
 
-        public void OnPollCompleted(IList<string> identifiers)
+        public void OnPollCompleted(IList<string> identifiers) =>
+            OnNotifyFlagsLoaded(identifiers);
         {
             OnNotifyFlagsLoaded(identifiers);
         }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -465,22 +465,22 @@ namespace io.harness.cfsdk.client.api
         
         private T LogAndReturnDefault<T>(FeatureConfigKind kind, string key, Target target, T defaultValue)
         {
-            logger.LogWarning(
-                "SDK not initialized or failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId}. Returning default variation {DefaultValue}", 
-                kind, target?.Identifier ?? "null target", key, defaultValue);
-            var defaultValueString = defaultValue?.ToString() ?? "null";
-            LogEvaluationFailureError(kind, key, target, defaultValueString);
+            LogEvaluationFailureError(kind, key, target, defaultValue?.ToString() ?? "null");
             return defaultValue;
         }
 
-        
-        public void LogEvaluationFailureError(FeatureConfigKind kind, string featureKey, dto.Target target,
+
+        private void LogEvaluationFailureError(FeatureConfigKind kind, string featureKey, Target target,
             string defaultValue)
         {
-            if (logger.IsEnabled(LogLevel.Warning))
-                logger.LogWarning(
-                    "SDKCODE(eval:6001): Failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId} and the default variation {DefaultValue} is being returned",
-                    kind, target?.Identifier ?? "null target", featureKey, defaultValue);
+            if (!logger.IsEnabled(LogLevel.Warning)) return;
+
+            // Avoid string concatenation in critical path.
+            logger.LogWarning(
+                SdkInitialized
+                    ? "SDKCODE(eval:6001): Failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId} and the default variation {DefaultValue} is being returned"
+                    : "SDKCODE(eval:6001): SDK Not initialized - Failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId} and the default variation {DefaultValue} is being returned",
+                kind, target?.Identifier ?? "null target", featureKey, defaultValue);
         }
     }
 }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -193,7 +193,7 @@ namespace io.harness.cfsdk.client.api
         {
             OnNotifyEvaluationChanged(identifier);
         }
-        
+
         public void OnFlagsLoaded(List<string> identifiers)
         {
             OnNotifyFlagsLoaded(identifiers);

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -36,6 +36,7 @@ namespace io.harness.cfsdk.client.api
 
         public event EventHandler InitializationCompleted;
         public event EventHandler<string> EvaluationChanged;
+        public event EventHandler<string[]> FlagsLoaded;
 
         private readonly CfClient parent;
         private readonly CountdownEvent sdkReadyLatch = new(1);
@@ -189,7 +190,14 @@ namespace io.harness.cfsdk.client.api
         {
             OnNotifyEvaluationChanged(identifier);
         }
-
+        
+        public void OnFlagsLoaded(string[] identifiers)
+        {
+            // TODO implement me
+            // OnNotifyEvaluationChanged(identifier);
+            
+        }
+        
         public void OnFlagDeleted(string identifier)
         {
             OnNotifyEvaluationChanged(identifier);
@@ -217,6 +225,11 @@ namespace io.harness.cfsdk.client.api
         private void OnNotifyEvaluationChanged(string identifier)
         {
             EvaluationChanged?.Invoke(parent, identifier);
+        }
+        
+        private void OnNotifyFlagsLoaded(string[] identifiers)
+        {
+            FlagsLoaded?.Invoke(parent, identifiers);
         }
 
         public bool BoolVariation(string key, Target target, bool defaultValue)

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -185,6 +185,12 @@ namespace io.harness.cfsdk.client.api
         {
 
         }
+
+        public void OnPollRan(List<string> identifiers)
+        {
+            OnNotifyFlagsLoaded(identifiers);
+        }
+
         #endregion
 
         #region Repository callback

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -151,6 +151,13 @@ namespace io.harness.cfsdk.client.api
             logger.LogInformation("SDKCODE(init:1000): The SDK has successfully initialized");
             logger.LogInformation("SDK version: " + Assembly.GetExecutingAssembly().GetName().Version);
         }
+        
+        public void OnAuthenticationFailure()
+        {
+            SdkInitialized = false;
+            // Auth has failed so we unblock the WaitForInitialization call 
+            sdkReadyLatch.Signal();
+        }
 
         /// <summary>
         /// SDK has authenticated and at least one poll of flags has happened

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -195,9 +195,12 @@ namespace io.harness.cfsdk.client.api
 
         }
 
-        public void OnPollCompleted(IList<string> identifiers)
+        public void OnPollCompleted()
         {
-            OnNotifyFlagsLoaded(identifiers);
+            // Check if there are any subscribers to the FlagsLoaded event before calling repository.GetFlags()
+            if (FlagsLoaded == null) return;
+            var flagIDs = repository.GetFlags();
+            OnNotifyFlagsLoaded(flagIDs);
         }
 
         #endregion

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -227,7 +227,7 @@ namespace io.harness.cfsdk.client.api
 
                 if (logger.IsEnabled(LogLevel.Warning))
                     logger.LogWarning(
-                        "SDK not initialized, returning default variation");
+                        "SDK not initialized, returning default variation for {Flag}", key);
                 LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
                 return defaultValue;
 

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -230,8 +230,8 @@ namespace io.harness.cfsdk.client.api
                         "SDK not initialized, returning default variation for {Flag}", key);
                 LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
                 return defaultValue;
-
             }
+
             catch (InvalidCacheStateException ex)
             {
                 if (logger.IsEnabled(LogLevel.Warning))
@@ -255,6 +255,7 @@ namespace io.harness.cfsdk.client.api
                 {
                     return evaluator.BoolVariation(key, target, defaultValue);
                 }
+                
                 catch (InvalidCacheStateException)
                 {
                     if (logger.IsEnabled(LogLevel.Error))
@@ -280,6 +281,7 @@ namespace io.harness.cfsdk.client.api
                 LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
                 return defaultValue;
             }
+            
             catch (InvalidCacheStateException ex)
             {
                 if (logger.IsEnabled(LogLevel.Warning))
@@ -302,6 +304,7 @@ namespace io.harness.cfsdk.client.api
                 {
                     return evaluator.StringVariation(key, target, defaultValue);
                 }
+                
                 catch (InvalidCacheStateException)
                 {
                     if (logger.IsEnabled(LogLevel.Warning))
@@ -328,6 +331,7 @@ namespace io.harness.cfsdk.client.api
                 LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
                 return defaultValue;
             }
+            
             catch (InvalidCacheStateException ex)
             {
                 if (logger.IsEnabled(LogLevel.Warning))
@@ -350,6 +354,7 @@ namespace io.harness.cfsdk.client.api
                 {
                     return evaluator.NumberVariation(key, target, defaultValue);
                 }
+                
                 catch (InvalidCacheStateException)
                 {
                     if (logger.IsEnabled(LogLevel.Warning))
@@ -375,6 +380,7 @@ namespace io.harness.cfsdk.client.api
                 LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                 return defaultValue;
             }
+            
             catch (InvalidCacheStateException ex)
             {
                 if (logger.IsEnabled(LogLevel.Warning))
@@ -396,6 +402,7 @@ namespace io.harness.cfsdk.client.api
                 {
                     return evaluator.JsonVariationToken(key, target, defaultValue);
                 }
+                
                 catch (InvalidCacheStateException)
                 {
                     if (logger.IsEnabled(LogLevel.Warning))

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -43,9 +43,9 @@ namespace io.harness.cfsdk.client.api
         private readonly CountdownEvent sdkReadyLatch = new(1);
         
         // Use property SdkInitialized for thread-safe access 
-        private int sdkInitialized; 
-    
-        public bool SdkInitialized 
+        private int sdkInitialized;
+
+        private bool SdkInitialized 
         { 
             get => Interlocked.CompareExchange(ref sdkInitialized, 0, 0) == 1;
             set => Interlocked.Exchange(ref sdkInitialized, value ? 1 : 0);

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -186,7 +186,7 @@ namespace io.harness.cfsdk.client.api
 
         }
 
-        public void OnPollRan(List<string> identifiers)
+        public void OnPollCompleted(List<string> identifiers)
         {
             OnNotifyFlagsLoaded(identifiers);
         }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -133,10 +133,10 @@ namespace io.harness.cfsdk.client.api
 
             logger.LogTrace("Signal sdkReadyLatch to release");
             sdkReadyLatch.Signal();
-            logger.LogInformation("SDKCODE(init:1000): The SDK has successfully initialized");
-            logger.LogInformation("SDK version: " + Assembly.GetExecutingAssembly().GetName().Version);
             OnNotifyInitializationCompleted();
             SetSdkInitialized(true);
+            logger.LogInformation("SDKCODE(init:1000): The SDK has successfully initialized");
+            logger.LogInformation("SDK version: " + Assembly.GetExecutingAssembly().GetName().Version);
         }
 
         /// <summary>
@@ -478,6 +478,7 @@ namespace io.harness.cfsdk.client.api
             this.polling?.Stop();
             this.update?.Stop();
             this.metric?.Stop();
+            this.SetSdkInitialized(false);
             logger.LogDebug("InnerClient was closed");
         }
 

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -134,11 +134,11 @@ namespace io.harness.cfsdk.client.api
             metric.Start();
 
             logger.LogTrace("Signal sdkReadyLatch to release");
+            SetSdkInitialized(true);
             sdkReadyLatch.Signal();
             OnNotifyInitializationCompleted();
             var flagIDs = repository.GetFlags();
             OnNotifyFlagsLoaded(flagIDs);
-            SetSdkInitialized(true);
             logger.LogInformation("SDKCODE(init:1000): The SDK has successfully initialized");
             logger.LogInformation("SDK version: " + Assembly.GetExecutingAssembly().GetName().Version);
         }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -195,8 +195,7 @@ namespace io.harness.cfsdk.client.api
 
         }
 
-        public void OnPollCompleted(IList<string> identifiers) =>
-            OnNotifyFlagsLoaded(identifiers);
+        public void OnPollCompleted(IList<string> identifiers)
         {
             OnNotifyFlagsLoaded(identifiers);
         }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -139,11 +139,15 @@ namespace io.harness.cfsdk.client.api
             metric.Start();
 
             logger.LogTrace("Signal sdkReadyLatch to release");
-            SdkInitialized = false;
+            SdkInitialized = true;
             sdkReadyLatch.Signal();
             OnNotifyInitializationCompleted();
-            var flagIDs = repository.GetFlags();
-            OnNotifyFlagsLoaded(flagIDs);
+            // Check if there are any subscribers to the FlagsLoaded event before calling repository.GetFlags()
+            if (FlagsLoaded != null)
+            {
+                var flagIDs = repository.GetFlags();
+                OnNotifyFlagsLoaded(flagIDs);
+            }
             logger.LogInformation("SDKCODE(init:1000): The SDK has successfully initialized");
             logger.LogInformation("SDK version: " + Assembly.GetExecutingAssembly().GetName().Version);
         }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -287,7 +287,7 @@ namespace io.harness.cfsdk.client.api
                 
                 catch (InvalidCacheStateException)
                 {
-                    if (logger.IsEnabled(LogLevel.Error))
+                    if (logger.IsEnabled(LogLevel.Warning))
                         logger.LogWarning(
                             "SDK not initialized, returning default variation for {Flag}", key);
 

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -461,7 +461,8 @@ namespace io.harness.cfsdk.client.api
             logger.LogWarning(
                 "SDK not initialized or failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId}. Returning default variation {DefaultValue}", 
                 kind, target?.Identifier ?? "null target", key, defaultValue);
-            LogEvaluationFailureError(kind, key, target, defaultValue.ToString());
+            var defaultValueString = defaultValue?.ToString() ?? "null";
+            LogEvaluationFailureError(kind, key, target, defaultValueString);
             return defaultValue;
         }
 

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -4,6 +4,7 @@ using io.harness.cfsdk.client.connector;
 using io.harness.cfsdk.HarnessOpenAPIService;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -36,7 +37,7 @@ namespace io.harness.cfsdk.client.api
 
         public event EventHandler InitializationCompleted;
         public event EventHandler<string> EvaluationChanged;
-        public event EventHandler<string[]> FlagsLoaded;
+        public event EventHandler<List<string>> FlagsLoaded;
 
         private readonly CfClient parent;
         private readonly CountdownEvent sdkReadyLatch = new(1);
@@ -135,6 +136,8 @@ namespace io.harness.cfsdk.client.api
             logger.LogTrace("Signal sdkReadyLatch to release");
             sdkReadyLatch.Signal();
             OnNotifyInitializationCompleted();
+            var flagIDs = repository.GetFlags();
+            OnNotifyFlagsLoaded(flagIDs);
             SetSdkInitialized(true);
             logger.LogInformation("SDKCODE(init:1000): The SDK has successfully initialized");
             logger.LogInformation("SDK version: " + Assembly.GetExecutingAssembly().GetName().Version);
@@ -191,7 +194,7 @@ namespace io.harness.cfsdk.client.api
             OnNotifyEvaluationChanged(identifier);
         }
         
-        public void OnFlagsLoaded(string[] identifiers)
+        public void OnFlagsLoaded(List<string> identifiers)
         {
             OnNotifyFlagsLoaded(identifiers);
         }
@@ -225,7 +228,7 @@ namespace io.harness.cfsdk.client.api
             EvaluationChanged?.Invoke(parent, identifier);
         }
         
-        private void OnNotifyFlagsLoaded(string[] identifiers)
+        private void OnNotifyFlagsLoaded(List<string> identifiers)
         {
             FlagsLoaded?.Invoke(parent, identifiers);
         }

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -254,18 +254,17 @@ namespace io.harness.cfsdk.client.api
             {
                 if (SdkInitialized) return evaluator.BoolVariation(key, target, defaultValue);
 
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(
-                        "SDK not initialized, returning default variation for {Flag}", key);
+                logger.LogWarning(
+                    "SDK not initialized, returning default variation for {Flag}", key);
                 LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
                 return defaultValue;
             }
 
             catch (InvalidCacheStateException ex)
             {
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating boolean variation for flag {Key}, refreshing cache and retrying evaluation ", key);
+                logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating boolean variation for flag {Key}, refreshing cache and retrying evaluation ",
+                    key);
 
                 // Attempt to refresh cache
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromMilliseconds(2000));
@@ -273,8 +272,9 @@ namespace io.harness.cfsdk.client.api
                 // If the refresh has failed or exceeded the timout, return default variation
                 if (result != RefreshOutcome.Success)
                 {
-                    if (logger.IsEnabled(LogLevel.Error))
-                        logger.LogError(ex, "Refreshing cache for boolean variation for flag {Key} failed, returning default variation ", key);
+                    logger.LogError(ex,
+                        "Refreshing cache for boolean variation for flag {Key} failed, returning default variation ",
+                        key);
 
                     LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
                     return defaultValue;
@@ -287,9 +287,8 @@ namespace io.harness.cfsdk.client.api
                 
                 catch (InvalidCacheStateException)
                 {
-                    if (logger.IsEnabled(LogLevel.Warning))
-                        logger.LogWarning(
-                            "SDK not initialized, returning default variation for {Flag}", key);
+                    logger.LogWarning(
+                        "SDK not initialized, returning default variation for {Flag}", key);
 
                     LogEvaluationFailureError(FeatureConfigKind.Boolean, key, target, defaultValue.ToString());
                     return defaultValue;
@@ -303,9 +302,8 @@ namespace io.harness.cfsdk.client.api
             {
                 if (SdkInitialized) return evaluator.StringVariation(key, target, defaultValue);
 
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(
-                        "SDK not initialized, returning default variation for {Flag}", key);
+                logger.LogWarning(
+                    "SDK not initialized, returning default variation for {Flag}", key);
                 
                 LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
                 return defaultValue;
@@ -313,18 +311,16 @@ namespace io.harness.cfsdk.client.api
             
             catch (InvalidCacheStateException ex)
             {
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(ex,
-                        "Invalid cache state detected when evaluating string variation for flag {Key}, refreshing cache and retrying evaluation",
-                        key);
+                logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating string variation for flag {Key}, refreshing cache and retrying evaluation",
+                    key);
 
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
                 if (result != RefreshOutcome.Success)
                 {
-                    if (logger.IsEnabled(LogLevel.Error))
-                        logger.LogError(
-                            "Refreshing cache for string variation for flag {Key} failed, returning default variation",
-                            key);
+                    logger.LogError(
+                        "Refreshing cache for string variation for flag {Key} failed, returning default variation",
+                        key);
                     LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
                     return defaultValue;
                 }
@@ -336,10 +332,9 @@ namespace io.harness.cfsdk.client.api
                 
                 catch (InvalidCacheStateException)
                 {
-                    if (logger.IsEnabled(LogLevel.Warning))
-                        logger.LogWarning(
-                            "Attempted re-evaluation of string variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                            key);
+                    logger.LogWarning(
+                        "Attempted re-evaluation of string variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                        key);
                     LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
                     return defaultValue;
                 }
@@ -353,9 +348,8 @@ namespace io.harness.cfsdk.client.api
             {
                 if (SdkInitialized) return evaluator.NumberVariation(key, target, defaultValue);
 
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(
-                        "SDK not initialized, returning default variation for {Flag}", key);
+                logger.LogWarning(
+                    "SDK not initialized, returning default variation for {Flag}", key);
                 
                 LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
                 return defaultValue;
@@ -363,17 +357,15 @@ namespace io.harness.cfsdk.client.api
             
             catch (InvalidCacheStateException ex)
             {
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(ex,
-                        "Invalid cache state detected when evaluating number variation for flag {Key}, refreshing cache and retrying evaluation",
-                        key);
+                logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating number variation for flag {Key}, refreshing cache and retrying evaluation",
+                    key);
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
                 if (result != RefreshOutcome.Success)
                 {
-                    if (logger.IsEnabled(LogLevel.Error))
-                        logger.LogError(
-                            "Refreshing cache for number variation for flag {Key} failed, returning default variation",
-                            key);
+                    logger.LogError(
+                        "Refreshing cache for number variation for flag {Key} failed, returning default variation",
+                        key);
 
                     LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
                     return defaultValue;
@@ -386,10 +378,9 @@ namespace io.harness.cfsdk.client.api
                 
                 catch (InvalidCacheStateException)
                 {
-                    if (logger.IsEnabled(LogLevel.Warning))
-                        logger.LogWarning(
-                            "Attempted re-evaluation of number variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                            key);
+                    logger.LogWarning(
+                        "Attempted re-evaluation of number variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                        key);
                     LogEvaluationFailureError(FeatureConfigKind.Int, key, target, defaultValue.ToString());
                     return defaultValue;
                 }
@@ -402,9 +393,8 @@ namespace io.harness.cfsdk.client.api
             {
                 if (SdkInitialized) return evaluator.JsonVariationToken(key, target, defaultValue);
 
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(
-                        "SDK not initialized, returning default variation for {Flag}", key);
+                logger.LogWarning(
+                    "SDK not initialized, returning default variation for {Flag}", key);
                 
                 LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                 return defaultValue;
@@ -412,17 +402,15 @@ namespace io.harness.cfsdk.client.api
             
             catch (InvalidCacheStateException ex)
             {
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(ex,
-                        "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
-                        key);
+                logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
+                    key);
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
                 if (result != RefreshOutcome.Success)
                 {
-                    if (logger.IsEnabled(LogLevel.Error))
-                        logger.LogError(
-                            "Refreshing cache for json variation for flag {Key} failed, returning default variation",
-                            key);
+                    logger.LogError(
+                        "Refreshing cache for json variation for flag {Key} failed, returning default variation",
+                        key);
                     LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                     return defaultValue;
                 }
@@ -431,13 +419,12 @@ namespace io.harness.cfsdk.client.api
                 {
                     return evaluator.JsonVariationToken(key, target, defaultValue);
                 }
-                
+
                 catch (InvalidCacheStateException)
                 {
-                    if (logger.IsEnabled(LogLevel.Warning))
-                        logger.LogWarning(
-                            "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                            key);
+                    logger.LogWarning(
+                        "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                        key);
                     LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                     return defaultValue;
                 }
@@ -451,26 +438,23 @@ namespace io.harness.cfsdk.client.api
             {
                 if (SdkInitialized) return evaluator.JsonVariation(key, target, defaultValue);
 
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(
-                        "SDK not initialized, returning default variation for {Flag}", key);
+                logger.LogWarning(
+                    "SDK not initialized, returning default variation for {Flag}", key);
                 
                 LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                 return defaultValue;
             }
             catch (InvalidCacheStateException ex)
             {
-                if (logger.IsEnabled(LogLevel.Warning))
-                    logger.LogWarning(ex,
-                        "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
-                        key);
+                logger.LogWarning(ex,
+                    "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
+                    key);
                 var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
                 if (result != RefreshOutcome.Success)
                 {
-                    if (logger.IsEnabled(LogLevel.Error))
-                        logger.LogError(
-                            "Refreshing cache for json variation for flag {Key} failed, returning default variation",
-                            key);
+                    logger.LogError(
+                        "Refreshing cache for json variation for flag {Key} failed, returning default variation",
+                        key);
                     LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                     return defaultValue;
                 }
@@ -481,10 +465,9 @@ namespace io.harness.cfsdk.client.api
                 }
                 catch (InvalidCacheStateException)
                 {
-                    if (logger.IsEnabled(LogLevel.Warning))
-                        logger.LogWarning(
-                            "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                            key);
+                    logger.LogWarning(
+                        "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                        key);
                     LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue.ToString());
                     return defaultValue;
                 }

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -89,7 +89,7 @@ namespace io.harness.cfsdk.client.api
 
             try
             {
-                Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() }).Wait();
+                Task.WhenAll(new List<Task> { ProcessFlags(false), ProcessSegments() }).Wait();
             }
             catch (Exception ex)
             {
@@ -109,14 +109,14 @@ namespace io.harness.cfsdk.client.api
             pollTimer = null;
 
         }
-        private async Task ProcessFlags()
+        private async Task ProcessFlags(bool isPollingCall)
         {
             try
             {
                 logger.LogDebug("Fetching flags started");
                 var flags = await this.connector.GetFlags();
                 logger.LogDebug("Fetching flags finished");
-                repository.SetFlags(flags);
+                repository.SetFlags(flags, isPollingCall);
                 logger.LogDebug("Loaded {SegmentRuleCount} flags", flags.Count());
 
             }
@@ -154,7 +154,7 @@ namespace io.harness.cfsdk.client.api
                 }
 
                 var processSegmentsTask = Task.Run(async () => await ProcessSegments());
-                var processFlagsTask = Task.Run(async () => await ProcessFlags());
+                var processFlagsTask = Task.Run(async () => await ProcessFlags(false));
 
                 try
                 {
@@ -219,7 +219,7 @@ namespace io.harness.cfsdk.client.api
                 }
                 try
                 {
-                    var task = Task.Run(async () => await ProcessFlags());
+                    var task = Task.Run(async () => await ProcessFlags(false));
                     var refreshSuccessful = task.Wait(timeout);
                     if (refreshSuccessful)
                     {
@@ -254,7 +254,7 @@ namespace io.harness.cfsdk.client.api
             try
             {
                 logger.LogDebug("Running polling iteration");
-                await Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() });
+                await Task.WhenAll(new List<Task> { ProcessFlags(true), ProcessSegments() });
 
                 if (isInitialized) return;
                 isInitialized = true;

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -25,7 +25,7 @@ namespace io.harness.cfsdk.client.api
 
         void OnPollError(string message);
 
-        void OnPollCompleted(IList<string> identifiers);
+        void OnPollCompleted();
     }
 
     internal interface IPollingProcessor
@@ -257,8 +257,7 @@ namespace io.harness.cfsdk.client.api
             {
                 logger.LogDebug("Running polling iteration");
                 await Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() });
-                var flagIDs = repository.GetFlags();
-                callback.OnPollCompleted(flagIDs);
+                callback.OnPollCompleted();
                 if (isInitialized) return;
                 isInitialized = true;
                 callback?.OnPollerReady();

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -25,7 +25,7 @@ namespace io.harness.cfsdk.client.api
 
         void OnPollError(string message);
 
-        void OnPollRan(List<string> identifiers);
+        void OnPollCompleted(List<string> identifiers);
     }
 
     internal interface IPollingProcessor
@@ -258,7 +258,7 @@ namespace io.harness.cfsdk.client.api
                 logger.LogDebug("Running polling iteration");
                 await Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() });
                 var flagIDs = repository.GetFlags();
-                callback.OnPollRan(flagIDs);
+                callback.OnPollCompleted(flagIDs);
                 if (isInitialized) return;
                 isInitialized = true;
                 callback?.OnPollerReady();

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -25,7 +25,7 @@ namespace io.harness.cfsdk.client.api
 
         void OnPollError(string message);
 
-        void OnPollCompleted(List<string> identifiers);
+        void OnPollCompleted(IList<string> identifiers);
     }
 
     internal interface IPollingProcessor

--- a/client/api/Repository.cs
+++ b/client/api/Repository.cs
@@ -179,12 +179,12 @@ namespace io.harness.cfsdk.client.api
         }
         
         
-        private List<string> GetFlagIdentifiers()
+        private IList<string> GetFlagIdentifiers()
         {
             rwLock.EnterReadLock();
             try
             {
-                List<string> flagIdentifiers = new List<string>();
+                IList<string> flagIdentifiers = new List<string>();
                 ICollection<string> keys = this.store != null ? this.store.Keys() : this.cache.Keys();
                 foreach (string key in keys)
                 {

--- a/client/api/Repository.cs
+++ b/client/api/Repository.cs
@@ -14,6 +14,7 @@ namespace io.harness.cfsdk.client.api
     internal interface IRepositoryCallback
     {
         void OnFlagStored(string identifier);
+        void OnFlagsLoaded(string[] identifiers);
         void OnFlagDeleted(string identifier);
         void OnSegmentStored(string identifier);
         void OnSegmentDeleted(string identifier);
@@ -278,7 +279,7 @@ namespace io.harness.cfsdk.client.api
         public void SetFlags(IEnumerable<FeatureConfig> flags)
         {
             // Collect updated flag IDs to notify onFlagStored callback outside the rw lock
-            List<string> updatedIdentifiers = new List<string>();
+            // List<string> updatedIdentifiers = new List<string>();
             
             rwLock.EnterWriteLock();
             try
@@ -287,7 +288,7 @@ namespace io.harness.cfsdk.client.api
                 {
                     SortFlagRules(item);
                     Update(item.Feature, FlagKey(item.Feature), item);
-                    updatedIdentifiers.Add(item.Feature);
+                    // updatedIdentifiers.Add(item.Feature);
                 }
             }
             finally
@@ -295,10 +296,10 @@ namespace io.harness.cfsdk.client.api
                 rwLock.ExitWriteLock();
             }
             
-            foreach (var identifier in updatedIdentifiers)
-            {
-                this.callback?.OnFlagStored(identifier);
-            }
+            // foreach (var identifier in updatedIdentifiers)
+            // {
+            //     this.callback?.OnFlagStored(identifier);
+            // }
         }
 
         public void SetSegments(IEnumerable<Segment> segments)

--- a/client/api/Repository.cs
+++ b/client/api/Repository.cs
@@ -312,7 +312,7 @@ namespace io.harness.cfsdk.client.api
         public void SetFlags(IEnumerable<FeatureConfig> flags, bool isPollingCall)
         {
             // Collect updated flag IDs to notify onFlagStored callback outside the rw lock
-            List<string> identifiers = new List<string>();
+            var identifiers = new List<string>();
             
             rwLock.EnterWriteLock();
             try
@@ -329,11 +329,10 @@ namespace io.harness.cfsdk.client.api
             {
                 rwLock.ExitWriteLock();
             }
-            
-            // foreach (var identifier in updatedIdentifiers)
-            // {
-            //     this.callback?.OnFlagStored(identifier);
-            // }
+
+            // We don't want to send this callback on init, only polling, because
+            // groups will not be loaded
+            // TODO - actually, should we not send after flags/group loaded?
             if (isPollingCall)
                 this.callback?.OnFlagsLoaded(identifiers);
         }

--- a/client/api/Repository.cs
+++ b/client/api/Repository.cs
@@ -14,7 +14,7 @@ namespace io.harness.cfsdk.client.api
     internal interface IRepositoryCallback
     {
         void OnFlagStored(string identifier);
-        void OnFlagsLoaded(List<string> identifiers);
+        void OnFlagsLoaded(IList<string> identifiers);
         void OnFlagDeleted(string identifier);
         void OnSegmentStored(string identifier);
         void OnSegmentDeleted(string identifier);
@@ -28,7 +28,7 @@ namespace io.harness.cfsdk.client.api
         void SetSegments(IEnumerable<Segment> segments);
 
         FeatureConfig GetFlag(string identifier);
-        List<string> GetFlags();
+        IList<string> GetFlags();
 
         Segment GetSegment(string identifier);
         IEnumerable<string> FindFlagsBySegment(string identifier);
@@ -68,7 +68,7 @@ namespace io.harness.cfsdk.client.api
             return GetFlag(identifier, true);
         }
         
-        public List<string> GetFlags()
+        public IList<string> GetFlags()
         {
             return GetFlagIdentifiers();
         }

--- a/client/api/rules/DistributionProcessor.cs
+++ b/client/api/rules/DistributionProcessor.cs
@@ -53,7 +53,7 @@ namespace io.harness.cfsdk.client.api.rules
                     return false;
                 }
 
-                logger.LogWarning("SDKCODE(eval:6002): BucketBy attribute not found in target attributes, falling back to 'identifier': missing={missing_attr}, using value={value}", oldBB, value);
+                logger.LogWarning("SDKCODE(eval:6002): BucketBy attribute not found in target attributes, falling back to 'identifier'");
             }
 
             Strategy strategy = new Strategy(value, bucketBy, loggerFactory);
@@ -61,10 +61,9 @@ namespace io.harness.cfsdk.client.api.rules
             if (logger.IsEnabled(LogLevel.Debug))
             {
                 logger.LogDebug(
-                    "MM3 percentage_check={percentage} bucket_by={bucket_by} value={value} bucket={bucket}",
+                    "MM3 percentage_check={percentage} bucket_by={bucket_by} bucket={bucket}",
                     percentage,
                     bucketBy,
-                    value ?? "",
                     bucketId);
             }
             return percentage > 0 && bucketId <= percentage;

--- a/client/api/rules/Strategy.cs
+++ b/client/api/rules/Strategy.cs
@@ -27,10 +27,6 @@ namespace io.harness.cfsdk.client.api.rules
         public int loadNormalizedNumberWithNormalizer(int normalizer)
         {
             byte[] valueBytes = Encoding.ASCII.GetBytes(bucketBy + ":" + value);
-            if (logger.IsEnabled(LogLevel.Debug))
-            {
-                logger.LogDebug("MM3 input [{input}]", Encoding.UTF8.GetString(valueBytes));
-            }
             HashAlgorithm hasher = MurmurHash.Create32(seed: 0);
             var hashcode = (uint)BitConverter.ToInt32(hasher.ComputeHash(valueBytes), 0);
             return (int)(hashcode % normalizer) + 1;

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -314,7 +314,7 @@ namespace io.harness.cfsdk.client.connector
             if (string.IsNullOrWhiteSpace(apiKey)) {
                 var errorMsg = "SDKCODE(init:1002):The SDK has failed to initialize due to a missing or empty API key.";
                 logger.LogError(errorMsg);
-                throw new CfClientException(errorMsg);
+                throw new CfClientUnrecoverableException(errorMsg);
             }
 
             try
@@ -359,14 +359,13 @@ namespace io.harness.cfsdk.client.connector
             }
             catch (ApiException ex)
             {
-                logger.LogError(ex, "SDKCODE(init:1001):The SDK has failed to initialize due to the following authentication error: {reason}", ex.Message);
 
                 if (ex.StatusCode == (int)HttpStatusCode.Unauthorized || ex.StatusCode == (int)HttpStatusCode.Forbidden)
                 {
                     var errorMsg = "SDKCODE(init:1001):The SDK has failed to initialize due to the following authentication error: Invalid apiKey. Defaults will be served.";
-                    logger.LogError(errorMsg);
-                    throw new CfClientException(errorMsg);
+                    throw new CfClientUnrecoverableException(errorMsg);
                 }
+                logger.LogError(ex, "SDKCODE(init:1001):The SDK has failed to initialize due to the following authentication error: {reason}", ex.Message);
                 throw new CfClientException(ex.Message);
             }
         }

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -313,7 +313,6 @@ namespace io.harness.cfsdk.client.connector
         {
             if (string.IsNullOrWhiteSpace(apiKey)) {
                 var errorMsg = "SDKCODE(init:1002):The SDK has failed to initialize due to a missing or empty API key.";
-                logger.LogError(errorMsg);
                 throw new CfClientUnrecoverableException(errorMsg);
             }
 

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -136,10 +136,20 @@ client.InitializationCompleted += (sender, e) =>
     // fired when authentication is completed and recent configuration is fetched from server
     Console.WriteLine("Notification Initialization Completed");
 };
-client.EvaluationChanged += (sender, identifier) =>
+client.EvaluationChanged += (sender, flagIdentifier) =>
 {
-    // Fired when flag value changes.
-    Console.WriteLine($"Flag changed for {identifier}");
+    // Fired when flag value changes from streaming events.
+    Console.WriteLine($"Flag changed for {flagIdentifier}");
+};
+
+client.FlagsLoaded += (sender, flagIdentifiers) =>
+{
+    // Fired once when the SDK has initiailized, and subsquently on each poll if streaming is disabled or has disconnected
+    // and fallen back to polling
+    foreach (var flagIdentifier in flagIdentifiers)
+    {
+        Console.WriteLine($"Flags loaded: Flag '{flagIdentifier}");
+    }
 };
 ```
 

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -130,6 +130,9 @@ Use the appropriate method to fetch the desired Evaluation of a certain type.
 
 Library exposes two events for user to subscribe on getting internal notifications.
 
+**Note** if `WaitForInitialization` is used to initialise the SDK, these events must be registered before the `WaitForInitialization` call. 
+See our   [getting_started](https://github.com/harness/ff-dotnet-server-sdk/blob/main/examples/getting_started/Program.cs) application for an example of this.
+
 ```c#
 client.InitializationCompleted += (sender, e) =>
 {

--- a/examples/getting_started/Program.cs
+++ b/examples/getting_started/Program.cs
@@ -34,7 +34,7 @@ namespace getting_started
                 .Attributes(new Dictionary<string, string> { { "email", "demo@harness.io" } })
                 .build();
 
-            // Add some sample events
+            // Events need to be created **before** calling WaitForInitialization
             client.InitializationCompleted += (sender, e) =>
             {
                 Console.WriteLine("NOTIFICATION: Initialization Completed");

--- a/examples/getting_started/Program.cs
+++ b/examples/getting_started/Program.cs
@@ -1,19 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using io.harness.cfsdk.client.dto;
-using io.harness.cfsdk.client.api;
 using System.Threading;
+using io.harness.cfsdk.client.api;
+using io.harness.cfsdk.client.dto;
 using Serilog;
 using Serilog.Extensions.Logging;
 
 namespace getting_started
 {
-    class Program
+    internal class Program
     {
-        public static String apiKey = Environment.GetEnvironmentVariable("FF_API_KEY");
-        public static String flagName = Environment.GetEnvironmentVariable("FF_FLAG_NAME") is string v && v.Length > 0 ? v : "harnessappdemodarkmode";
+        public static string apiKey = Environment.GetEnvironmentVariable("FF_API_KEY");
 
-        static void Main(string[] args)
+        public static string flagName = Environment.GetEnvironmentVariable("FF_FLAG_NAME") is string v && v.Length > 0
+            ? v
+            : "harnessappdemodarkmode";
+
+        private static void Main(string[] args)
         {
             var loggerFactory = new SerilogLoggerFactory(
                 new LoggerConfiguration()
@@ -23,27 +26,36 @@ namespace getting_started
 
             // Create a feature flag client
             var client = new CfClient(apiKey, Config.Builder().LoggerFactory(loggerFactory).Build());
-            var isInit = client.WaitForInitialization(30000);
-            if (!isInit)
-            {
-                Console.WriteLine("Failed to init the SDK within 30seconds");
-            }
 
             // Create a target (different targets can get different results based on rules)
-            Target target = Target.builder()
-                            .Name("DotNET SDK")
-                            .Identifier("dotnetsdk")
-                            .Attributes(new Dictionary<string, string>(){{"email", "demo@harness.io"}})
-                            .build();
+            var target = Target.builder()
+                .Name("DotNET SDK")
+                .Identifier("dotnetsdk")
+                .Attributes(new Dictionary<string, string> { { "email", "demo@harness.io" } })
+                .build();
 
             // Add some sample events
-            client.InitializationCompleted += (sender, e) => { Console.WriteLine("NOTIFICATION: Initialization Completed"); };
-            client.EvaluationChanged += (sender, identifier) => { Console.WriteLine($"NOTIFICATION: Flag changed for '{identifier}'"); };
+            client.InitializationCompleted += (sender, e) =>
+            {
+                Console.WriteLine("NOTIFICATION: Initialization Completed");
+            };
+            client.EvaluationChanged += (sender, identifier) =>
+            {
+                var resultBool = client.boolVariation(flagName, target, false);
+                Console.WriteLine($"stream: Flag '{flagName}' = " + resultBool);
+            };
+            client.FlagsLoaded += (sender, identifiers) =>
+            {
+                foreach (var identifier in identifiers) Console.WriteLine($"Flag loaded: Flag '{identifier}");
+            };
 
-           // Loop forever reporting the state of the flag
+            var isInit = client.WaitForInitialization(30000);
+            if (!isInit) Console.WriteLine("Failed to init the SDK within 30seconds");
+
+            // Loop forever reporting the state of the flag
             while (true)
             {
-                bool resultBool = client.boolVariation(flagName, target, false);
+                var resultBool = client.boolVariation(flagName, target, false);
                 Console.WriteLine($"POLL: Flag '{flagName}' = " + resultBool);
                 Thread.Sleep(10 * 1000);
             }

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.0</Version>
+        <Version>1.7.1</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.0</PackageVersion>
-        <AssemblyVersion>1.7.0</AssemblyVersion>
+        <PackageVersion>1.7.1</PackageVersion>
+        <AssemblyVersion>1.7.1</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>

--- a/tests/evaluation-load-test/evaluation-load-test.csproj
+++ b/tests/evaluation-load-test/evaluation-load-test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <RootNamespace>evaluation_load_test</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/ff-server-sdk-test/AuthService.cs
+++ b/tests/ff-server-sdk-test/AuthService.cs
@@ -15,6 +15,10 @@ namespace ff_server_sdk_test
         {
             
         }
+
+        public void OnAuthenticationFailure()
+        {
+        }
     }
     [TestFixture]
     public class InnerClient


### PR DESCRIPTION
# What
This PR addresses three issues:
1. Adds a new `FlagsLoaded` event: event contains a list of flag identifiers that have been cached.  It fires at least once when the SDK has initiailized succesfully, and then on each poll which will take place only if streaming is disabled or has fallen back to polling due to a disconnection.  A check is made that the event has been subscribed to before pulling the IDs from the cache as an optimisation.

2. Fixes the `WaitForInitialzation()` call not unblocking if auth fails:
    - `401/403` errors are not retried and the call unblocks immediately and the SDK is placed into an un-initialized state.
    - All other errors are retried up to 10 times, after which the call unblocks and the SDK is placed into un-init state. 

3. Stops a cache refresh if a flag/group can't be found and the SDK is not initialised.

# Why
1. In previous versions of the SDK, we used to include a list of flag identifiers in the `EvaluationChanged` event, but this was changed to only handle streaming changes. This fixes that accidental breaking change and adds back in the behaviour but under a new event. 

2. If `WaitForInitilzation(timeout)` is not used, then the SDK will not unblock for init failures where retries have not worked. 

3. A cache refresh is not needed until the SDK has initialized. 

Also as a minor point tidies up the inner client method structure and logging.

# Testing
Manual:
1.
- Streaming enabled: event fires once on init
- Streaming disabled: event fires once on init and then once for each subsequent poll.
- TestGrid

2. Manual:
- Invalid API key unblocks immediately 
- Proxy server returning 500 errors unblocks after 10 retries

3. Manual: cache is not refreshed if SDK is not iniitalised 

Also TestGrid image built and suite ran. 