### PR TITLE
FFM-11801 Fix `client.close()` not exiting streaming 

### DIFF
--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -264,6 +264,11 @@ namespace io.harness.cfsdk.client.api
             }
             catch(Exception ex)
             {
+                if (ex is TaskCanceledException)
+                {
+                    logger.LogDebug("Polling thread cancelled");
+                    return;
+                }
                 logger.LogWarning(ex,"Polling failed with error: {reason}. Will retry in {pollIntervalInSeconds}", ex.Message, config.pollIntervalInSeconds);
                 callback?.OnPollError(ex.Message);
             }

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -22,6 +22,7 @@ namespace io.harness.cfsdk.client.connector
         private const int BaseDelayMs = 200; 
         private const int MaxDelayMs = 5000; 
         private static readonly Random Random = new();
+        private CancellationTokenSource cancellationTokenSource;
 
         public EventSource(HttpClient httpClient, string url, IUpdateCallback callback, ILoggerFactory loggerFactory)
         {
@@ -29,6 +30,7 @@ namespace io.harness.cfsdk.client.connector
             this.url = url;
             this.callback = callback;
             this.logger = loggerFactory.CreateLogger<EventSource>();
+            this.cancellationTokenSource = new CancellationTokenSource();
         }
 
         public void Close()
@@ -44,6 +46,8 @@ namespace io.harness.cfsdk.client.connector
         public void Stop()
         {
             logger.LogDebug("Stopping EventSource service.");
+            cancellationTokenSource.Cancel();
+
         }
 
         private string ReadLine(Stream stream, int timeoutMs)
@@ -71,7 +75,7 @@ namespace io.harness.cfsdk.client.connector
         private async Task StartStreaming()
         {
             var retryCount = 0;
-            while (true)
+            while (!cancellationTokenSource.Token.IsCancellationRequested)
             {
                 try
                 {

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -48,7 +48,6 @@ namespace io.harness.cfsdk.client.connector
         {
             logger.LogDebug("Stopping EventSource service.");
             cancellationTokenSource.Cancel();
-
         }
 
         private string ReadLine(Stream stream, int timeoutMs)

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -159,7 +159,10 @@ namespace io.harness.cfsdk.client.connector
                 }
                 finally
                 {
-                    callback.OnStreamDisconnected();
+                    if (!cancellationTokenSource.Token.IsCancellationRequested)
+                    {
+                        callback.OnStreamDisconnected();
+                    }
                 }
             }
         }

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -143,7 +143,8 @@ namespace io.harness.cfsdk.client.connector
                 {
                     if (cancellationTokenSource.Token.IsCancellationRequested)
                     {
-                       return;
+                        logger.LogInformation("SDKCODE(stream:5004): SSE thread exited");
+                        return;
                     }
                     retryCount++;
 


### PR DESCRIPTION
# What
If `client.close()` was called, the stream would remain open.  This adds a new cancellation token that is used throughout streaming code to ensure that connections and loops exit when the SDK is closed.  Also ensures that the fallback polling mechanism isn't started under this circumstance. 

# Why
The client should close all connections when closed, to avoid a memory leak situation. 

# Testing
.NET Core 5, 6, 7
.NET 4.8 on a Windows VM - this needs tested because the HTTP client behaves differently in this version for long lived streaming connections. 