### PR TITLE
FFM-12057: Integrate Community PR (#138)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,8 @@ if [ "$DOTNET_VERSION" -lt 8 ]; then
     OS=$(uname)
     if [ "$OS" == "Linux" ]; then
         # For Ubuntu/Debian-based systems
-        sudo apt-get update
-        sudo apt-get install -y dotnet-sdk-8.0
+        apt-get update
+        apt-get install -y dotnet-sdk-8.0
     elif [ "$OS" == "Darwin" ]; then
         # For macOS
         brew install --cask dotnet-sdk

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Check .NET version
+# Check .NET version installed
 echo ".NET version installed:"
 dotnet --version
 
@@ -10,32 +10,23 @@ git submodule update --init --recursive
 # Get the major version of the installed .NET SDK
 DOTNET_VERSION=$(dotnet --version | cut -d. -f1)
 
-# Check if .NET 8.0 is installed, if not, install it
+# Check if .NET 8.0 is installed, if not, install it locally
 if [ "$DOTNET_VERSION" -lt 8 ]; then
-    echo "FF .NET SDK requires .NET 8.0 or later to build. Attempting to install .NET 8.0..."
+    echo "FF .NET SDK requires .NET 8.0 or later to build. Attempting to install .NET 8.0 locally..."
 
-    # Detect the platform
-    OS=$(uname)
-    if [ "$OS" == "Linux" ]; then
-        # For Ubuntu/Debian-based systems
-        apt-get update
-        apt-get install -y dotnet-sdk-8.0
-    elif [ "$OS" == "Darwin" ]; then
-        # For macOS
-        brew install --cask dotnet-sdk
-    elif [[ "$OS" =~ MINGW|MSYS|CYGWIN ]]; then
-        # For Windows (Git Bash/Cygwin/WSL)
-        echo "Please manually download and install the .NET 8.0 SDK from https://dotnet.microsoft.com/download/dotnet/8.0"
-        exit 1
-    else
-        echo "Unsupported OS. Please install .NET 8.0 manually."
-        exit 1
-    fi
+    # Download the official .NET install script
+    wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
 
-    # Verify installation
-    dotnet --version
+    # Install .NET 8.0 SDK locally for the user
+    chmod +x dotnet-install.sh
+    ./dotnet-install.sh --channel 8.0
+
+    # Set DOTNET_ROOT and update PATH
+    export DOTNET_ROOT=$HOME/.dotnet
+    export PATH=$HOME/.dotnet:$PATH
+
+    # Verify the installation
     DOTNET_VERSION=$(dotnet --version | cut -d. -f1)
-
     if [ "$DOTNET_VERSION" -lt 8 ]; then
         echo ".NET 8.0 installation failed. Aborting."
         exit 1
@@ -46,6 +37,7 @@ else
     echo ".NET 8.0 or later is already installed."
 fi
 
+# Continue with build process
 set -x
 
 # Build the FF .NET SDK

--- a/build.sh
+++ b/build.sh
@@ -1,24 +1,62 @@
+#!/bin/bash
+
+# Check .NET version
 echo ".NET version installed:"
 dotnet --version
 
+# Initialize git submodules
 git submodule update --init --recursive
 
+# Get the major version of the installed .NET SDK
 DOTNET_VERSION=$(dotnet --version | cut -d. -f1)
-if [ "$DOTNET_VERSION" -lt 7 ]; then
-	echo "FF .NET SDK requires .NET 7 or later to build. Aborting"
-	exit 1
+
+# Check if .NET 8.0 is installed, if not, install it
+if [ "$DOTNET_VERSION" -lt 8 ]; then
+    echo "FF .NET SDK requires .NET 8.0 or later to build. Attempting to install .NET 8.0..."
+
+    # Detect the platform
+    OS=$(uname)
+    if [ "$OS" == "Linux" ]; then
+        # For Ubuntu/Debian-based systems
+        sudo apt-get update
+        sudo apt-get install -y dotnet-sdk-8.0
+    elif [ "$OS" == "Darwin" ]; then
+        # For macOS
+        brew install --cask dotnet-sdk
+    elif [[ "$OS" =~ MINGW|MSYS|CYGWIN ]]; then
+        # For Windows (Git Bash/Cygwin/WSL)
+        echo "Please manually download and install the .NET 8.0 SDK from https://dotnet.microsoft.com/download/dotnet/8.0"
+        exit 1
+    else
+        echo "Unsupported OS. Please install .NET 8.0 manually."
+        exit 1
+    fi
+
+    # Verify installation
+    dotnet --version
+    DOTNET_VERSION=$(dotnet --version | cut -d. -f1)
+
+    if [ "$DOTNET_VERSION" -lt 8 ]; then
+        echo ".NET 8.0 installation failed. Aborting."
+        exit 1
+    else
+        echo ".NET 8.0 installed successfully."
+    fi
+else
+    echo ".NET 8.0 or later is already installed."
 fi
 
 set -x
 
+# Build the FF .NET SDK
 dotnet pack ff-netF48-server-sdk.csproj
 
-# Install Tools needed for build
+# Install Tools needed for the build
 dotnet tool install --global coverlet.console --version 3.2.0
 dotnet tool install --global dotnet-reportgenerator-globaltool
 dotnet tool restore
 
-# Install Libraries needed for build and build
+# Restore and build libraries
 dotnet restore ff-netF48-server-sdk.csproj
 dotnet build ff-netF48-server-sdk.csproj --no-restore
 

--- a/client/connector/HarnessConnector.cs
+++ b/client/connector/HarnessConnector.cs
@@ -51,10 +51,17 @@ namespace io.harness.cfsdk.client.connector
 
         private static HttpClient CreateHttpClientWithTls(Config config, ILoggerFactory loggerFactory)
         {
+#if NET8_0_OR_GREATER
+            if (config.TlsTrustedCAs == null || !config.TlsTrustedCAs.Any())
+            {
+                return new HttpClient();
+            }
+#else
             if (config.TlsTrustedCAs.IsNullOrEmpty())
             {
                 return new HttpClient();
             }
+#endif
 
 #if (NETSTANDARD || NET461 || NET48)
             throw new NotSupportedException("Custom TLS certificates require .net5.0 target or greater");

--- a/examples/getting_started/getting_started.csproj
+++ b/examples/getting_started/getting_started.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RestoreSources>$(RestoreSources);https://api.nuget.org/v3/index.json</RestoreSources>
 
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 

--- a/examples/tls-example/tls-example.csproj
+++ b/examples/tls-example/tls-example.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>tls_example</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -13,7 +13,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <!-- The SDK must be built with .NET 7 however we must also keep compatibility with .NET 5/6 hence SupportedOSPlatformVersion=9 below -->
+        <!-- The SDK must be built with .NET 8 however we must also keep compatibility with .NET 5/6 hence SupportedOSPlatformVersion=9 below -->
         <TargetFrameworks>netstandard2.0;net461;net48;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
         <LangVersion>9.0</LangVersion>

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -35,20 +35,16 @@
 
     <!--
         When updating a package to the latest version, order is important when linking the dependency library to a specific target .NET version and newer versions should be referenced first.
-
-        See "System.IdentityModel.Tokens.Jwt".
+        For an example of this ordering, See "System.IdentityModel.Tokens.Jwt".
     -->
 
     <ItemGroup>
-        <!-- Unless proven otherwise, 4.0.0 catch all will not work, please add a specific reference for your FTFM package, preferably targeting latest. -->
-        <PackageReference Include="Disruptor" Version="6.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
-        <PackageReference Include="Disruptor" Version="4.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'" />
-
         <PackageReference Include="murmurhash" Version="1.0.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 
-        <!-- Unless proven otherwise, 6.36.0 catch all will not work, please add a specific reference for your FTFM package, preferably targeting latest. -->
+        <!-- Unless proven otherwise, 6.36.0 catch all will not work, so we need to list explicit versions for .NET 7.0 and greater. 
+        When adding a new TFM, specify the latest compatible version of System.IdentityModel.Tokens.Jwt for that TFM. -->
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.7.1" Condition="'$(TargetFramework)' == 'net7.0'" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.36.0" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'" />

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -2,16 +2,16 @@
 
     <PropertyGroup>
         <!-- The SDK must be built with .NET 7 however we must also keep compatibility with .NET 5/6 hence SupportedOSPlatformVersion=9 below -->
-        <TargetFrameworks>netstandard2.0;net461;net48;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net461;net48;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
         <LangVersion>9.0</LangVersion>
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.1</Version>
+        <Version>1.7.2</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.1</PackageVersion>
-        <AssemblyVersion>1.7.1</AssemblyVersion>
+        <PackageVersion>1.7.2</PackageVersion>
+        <AssemblyVersion>1.7.2</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2024</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
@@ -33,12 +33,26 @@
         <None Remove="tests\**;examples\**" />
     </ItemGroup>
 
+    <!--
+        When updating a package to the latest version, order is important when linking the dependency library to a specific target .NET version and newer versions should be referenced first.
+
+        See "System.IdentityModel.Tokens.Jwt".
+    -->
+
     <ItemGroup>
-        <PackageReference Include="Disruptor" Version="4.0.0" />
+        <!-- Unless proven otherwise, 4.0.0 catch all will not work, please add a specific reference for your FTFM package, preferably targeting latest. -->
+        <PackageReference Include="Disruptor" Version="6.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+        <PackageReference Include="Disruptor" Version="4.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'" />
+
         <PackageReference Include="murmurhash" Version="1.0.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
+
+        <!-- Unless proven otherwise, 6.36.0 catch all will not work, please add a specific reference for your FTFM package, preferably targeting latest. -->
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.7.1" Condition="'$(TargetFramework)' == 'net7.0'" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.36.0" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'" />
+
         <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net48'" />
         <PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/evaluation-load-test/evaluation-load-test.csproj
+++ b/tests/evaluation-load-test/evaluation-load-test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>evaluation_load_test</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 

--- a/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
+++ b/tests/ff-server-sdk-test/ff-server-sdk-test.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>ff_server_sdk_test</RootNamespace>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
@@ -24,7 +24,7 @@
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="WireMock.Net" Version="1.5.46" />
     <PackageReference Include="WireMock.Net.FluentAssertions" Version="1.5.46" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="6.0.0"/>
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Integrates community PR submission from https://github.com/harness/ff-dotnet-server-sdk/pull/138 for issue https://github.com/harness/ff-dotnet-server-sdk/issues/139

- Also removes `Disruptor` library as this has been unused since it was removed from Analytics code in 1.1.8: https://github.com/harness/ff-dotnet-server-sdk/compare/1.1.7...1.1.8 

# Testing
- Tested all versions of .NET we support: 8.0 / 7.0 / 6.0 / 5.0 / 4.6.1 
    - Tested 4.8 on a Windows VM
    - Tested auth / streaming / polling / metrics 