### PR TITLE
feat: [FFM-12553]: Improve logging of DNS errors

### DIFF
--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.3</Version>
+        <Version>1.7.4</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.3</PackageVersion>
-        <AssemblyVersion>1.7.3</AssemblyVersion>
+        <PackageVersion>1.7.4</PackageVersion>
+        <AssemblyVersion>1.7.4</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2025</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>


### PR DESCRIPTION
Currently the SDK will log a generic HTTP error string if the config host name does not exist:

`An error occurred while sending the request.`

Update the SDK to catch `HttpRequestException` and log more details to make it easier to diagnose DNS issues.

`[13:43:23 ERR] HttpRequestException: nodename nor servname provided, or not known (i_dot_not_exist:443) StatusCode=null HttpRequestError=NameResolutionError`