### PR TITLE
feat: Adds `XxxAsync()` methods to the `ICfClient` (and subsequent references)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 ========================
 
 ## Table of Contents
-**[Intro](#Intro)**<br>
-**[Requirements](#Requirements)**<br>
-**[Quickstart](#Quickstart)**<br>
-**[Further Reading](docs/further_reading.md)**<br>
-**[Build Instructions](docs/build.md)**<br>
+**[Intro](#Intro)**
+**[Requirements](#Requirements)**
+**[Quickstart](#Quickstart)**
+**[Further Reading](docs/further_reading.md)**
+**[Build Instructions](docs/build.md)**
 
 
 ## Intro

--- a/client/TaskExtensions.cs
+++ b/client/TaskExtensions.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace io.harness.cfsdk.client
+{
+    /// <summary>
+    /// Provides extension methods for running tasks.
+    /// </summary>
+    internal static class TaskExtensions
+    {
+        /// <summary>
+        /// Runs a task with a specified timeout. If the task does not complete within the timeout, a <see cref="TimeoutException"/> is thrown.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the value returned by the task.</typeparam>
+        /// <param name="task">The task to run.</param>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The value returned by the task.</returns>
+        internal static async Task<TValue> RunWithTimeout<TValue>(this Task<TValue> task, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            await ((Task)task).RunWithTimeout(timeout, cancellationToken);
+            return await task;
+        }
+
+        /// <summary>
+        /// Runs a task with a specified timeout. If the task does not complete within the timeout, a <see cref="TimeoutException"/> is thrown.
+        /// </summary>
+        /// <param name="task">The task to run.</param>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        internal static async Task RunWithTimeout(this Task task, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            var tasks = new List<Task>();
+            if (task != null)
+            {
+                tasks.Add(task);
+            }
+
+            await RunWithTimeout(tasks, timeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// Runs the collection of tasks with a specified timeout. If the tasks do not complete within the timeout, a <see cref="TimeoutException"/> is thrown.
+        /// </summary>
+        /// <param name="task">The tasks to run.</param>
+        /// <param name="timeout">The timeout.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        internal static async Task RunWithTimeout(this IEnumerable<Task> tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            var allTasks = Task.WhenAll(tasks);
+
+#if NET6_0_OR_GREATER
+            await allTasks.WaitAsync(timeout, cancellationToken);
+#else
+            var timeoutTask = Task.Delay(timeout, cancellationToken);
+            var completedTask = await Task.WhenAny(allTasks, timeoutTask);
+            if (completedTask == timeoutTask)
+            {
+                throw new TimeoutException();
+            }
+#endif
+        }
+    }
+}

--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -2,12 +2,13 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace io.harness.cfsdk.client.api
 {
-    public interface ICfClient
+    public interface ICfClient : IDisposable
     {
         Task Initialize(string apiKey);
         Task Initialize(string apiKey, Config config);
@@ -20,9 +21,14 @@ namespace io.harness.cfsdk.client.api
         bool WaitForInitialization(int timeoutMs);
 
         bool boolVariation(string key, dto.Target target, bool defaultValue);
+        Task<bool> boolVariationAsync(string key, dto.Target target, bool defaultValue, CancellationToken cancellationToken = default);
         string stringVariation(string key, dto.Target target, string defaultValue);
+        Task<string> stringVariationAsync(string key, dto.Target target, string defaultValue, CancellationToken cancellationToken = default);
         double numberVariation(string key, dto.Target target, double defaultValue);
+        Task<double> numberVariationAsync(string key, dto.Target target, double defaultValue, CancellationToken cancellationToken = default);
         JToken jsonVariationToken(string key, dto.Target target, JToken defaultValue);
+        Task<JToken> jsonVariationTokenAsync(string key, dto.Target target, JToken defaultValue, CancellationToken cancellationToken = default);
+        [Obsolete("This method only supports JSON objects. If a JSON array variation is returned it will result in a warning being logged and the default variation being returned. Use jsonVariationToken(string key, Target target, JToken defaultValue) since version 1.7.0 for support of both JSON objects and arrays.")]
         JObject jsonVariation(string key, dto.Target target, JObject defaultValue);
 
 
@@ -37,6 +43,7 @@ namespace io.harness.cfsdk.client.api
     {
         // Singleton implementation
         private static readonly Lazy<CfClient> lazy = new Lazy<CfClient>(() => new CfClient());
+        private bool isDisposed = false;
 
         /// <summary>
         /// Returns a <c>CfClient()</c> instance. Subsequent calls to <c>Instance</c> will return the same instance.
@@ -66,7 +73,7 @@ namespace io.harness.cfsdk.client.api
             add { client.EvaluationChanged += value; }
             remove { client.EvaluationChanged -= value; }
         }
-        
+
         public event EventHandler<IList<string>> FlagsLoaded
         {
             add { client.FlagsLoaded += value; }
@@ -108,10 +115,10 @@ namespace io.harness.cfsdk.client.api
             // Default logging is to console
             return LoggerFactory.Create(builder =>
             {
-                 builder
-                    .AddFilter("Microsoft", LogLevel.Warning)
-                    .AddFilter("System", LogLevel.Warning)
-                    .AddConsole();
+                builder
+                   .AddFilter("Microsoft", LogLevel.Warning)
+                   .AddFilter("System", LogLevel.Warning)
+                   .AddConsole();
             });
         }
 
@@ -188,7 +195,7 @@ namespace io.harness.cfsdk.client.api
         /// <param name="connector">A concrete class implementing IConnector for custom connections</param>
         public async Task Initialize(IConnector connector)
         {
-           await Initialize(connector, Config.Builder().Build());
+            await Initialize(connector, Config.Builder().Build());
         }
 
         /// <summary>
@@ -217,15 +224,40 @@ namespace io.harness.cfsdk.client.api
 
         // read values
         public bool boolVariation(string key, dto.Target target, bool defaultValue) { return client.BoolVariation(key, target, defaultValue);  }
+        public async Task<bool> boolVariationAsync(string key, dto.Target target, bool defaultValue, CancellationToken cancellationToken = default) { return await client.BoolVariationAsync(key, target, defaultValue, cancellationToken); }
         public string stringVariation(string key, dto.Target target, string defaultValue) { return client.StringVariation(key, target, defaultValue); }
+        public async Task<string> stringVariationAsync(string key, dto.Target target, string defaultValue, CancellationToken cancellationToken = default) { return await client.StringVariationAsync(key, target, defaultValue, cancellationToken); }
         public double numberVariation(string key, dto.Target target, double defaultValue) { return client.NumberVariation(key, target, defaultValue); }
+        public async Task<double> numberVariationAsync(string key, dto.Target target, double defaultValue, CancellationToken cancellationToken = default) { return await client.NumberVariationAsync(key, target, defaultValue, cancellationToken); }
         public JToken jsonVariationToken(string key, dto.Target target, JToken defaultValue) {  return client.JsonVariationToken(key, target, defaultValue); }
+        public async Task<JToken> jsonVariationTokenAsync(string key, dto.Target target, JToken defaultValue, CancellationToken cancellationToken = default) { return await client.JsonVariationTokenAsync(key, target, defaultValue, cancellationToken); }
         [Obsolete("This method only supports JSON objects. If a JSON array variation is returned it will result in a warning being logged and the default variation being returned. Use jsonVariationToken(string key, Target target, JToken defaultValue) since version 1.7.0 for support of both JSON objects and arrays.")]
         public JObject jsonVariation(string key, dto.Target target, JObject defaultValue) {  return client.JsonVariation(key, target, defaultValue); }
 
 
         // force message
-        public void Update(Message msg) { client.Update(msg, true);  }
+        public void Update(Message msg) { client.Update(msg, true); }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                Close();
+            }
+
+            isDisposed = true;
+        }
 
         public void Close()
         {

--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -42,7 +42,9 @@ namespace io.harness.cfsdk.client.api
     public class CfClient : ICfClient
     {
         // Singleton implementation
+#pragma warning disable CS0618 // Suppress warnings for using obsolete constructor
         private static readonly Lazy<CfClient> lazy = new Lazy<CfClient>(() => new CfClient());
+#pragma warning restore CS0618 // Restore warnings
         private bool isDisposed = false;
 
         /// <summary>

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -127,7 +127,7 @@ namespace io.harness.cfsdk.client.api
             {
                 if (!logger.IsEnabled(LogLevel.Warning)) return defaultValue;
 
-                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue);
+                LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue, ex);
                 return defaultValue;
             }
 
@@ -162,7 +162,7 @@ namespace io.harness.cfsdk.client.api
                 catch (JsonReaderException ex)
                 {
                     // Log the error if parsing fails
-                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, ex.Message);
+                    LogEvaluationFailureError(FeatureConfigKind.Json, key, target, ex.Message, ex);
                     return defaultValue;
                 }
             }
@@ -270,11 +270,12 @@ namespace io.harness.cfsdk.client.api
             return var;
         }
 
-        private void LogEvaluationFailureError<T>(FeatureConfigKind kind, string featureKey, Target target, T defaultValue)
+        private void LogEvaluationFailureError<T>(FeatureConfigKind kind, string featureKey, Target target, T defaultValue, Exception ex = null)
         {
             if (logger.IsEnabled(LogLevel.Warning))
             {
                 logger.LogWarning(
+                    ex,
                     "SDKCODE(eval:6001): Failed to evaluate {Kind} variation for {TargetId}, flag {FeatureId} and the default variation {DefaultValue} is being returned",
                     kind, target?.Identifier ?? "null target", featureKey, defaultValue?.ToString() ?? "null");
             }

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -61,7 +61,7 @@ namespace io.harness.cfsdk.client.api
         public bool BoolVariation(string key, Target target, bool defaultValue)
         {
             return BoolVariationAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<bool> BoolVariationAsync(
@@ -81,7 +81,7 @@ namespace io.harness.cfsdk.client.api
         public JToken JsonVariationToken(string key, Target target, JToken defaultValue)
         {
             return JsonVariationTokenAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<JToken> JsonVariationTokenAsync(
@@ -114,7 +114,7 @@ namespace io.harness.cfsdk.client.api
         public JObject JsonVariation(string key, Target target, JObject defaultValue)
         {
             return JsonVariationAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<JObject> JsonVariationAsync(
@@ -152,7 +152,7 @@ namespace io.harness.cfsdk.client.api
         public double NumberVariation(string key, Target target, double defaultValue)
         {
             return NumberVariationAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<double> NumberVariationAsync(
@@ -172,7 +172,7 @@ namespace io.harness.cfsdk.client.api
         public string StringVariation(string key, Target target, string defaultValue)
         {
             return StringVariationAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<string> StringVariationAsync(

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -123,7 +123,7 @@ namespace io.harness.cfsdk.client.api
             JObject defaultValue,
             CancellationToken cancellationToken = default)
         {
-            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.Json);
+            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.Json, cancellationToken);
             if (variation != null)
             {
                 try
@@ -161,7 +161,7 @@ namespace io.harness.cfsdk.client.api
             double defaultValue,
             CancellationToken cancellationToken = default)
         {
-            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.Int);
+            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.Int, cancellationToken);
             double res;
             if (variation != null && double.TryParse(variation.Value, out res)) return res;
 
@@ -181,7 +181,7 @@ namespace io.harness.cfsdk.client.api
             string defaultValue,
             CancellationToken cancellationToken = default)
         {
-            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.String);
+            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.String, cancellationToken);
             if (variation != null) return variation.Value;
 
             LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -8,8 +8,9 @@ using io.harness.cfsdk.HarnessOpenAPIService;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using Target = io.harness.cfsdk.client.dto.Target;
-using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
+using System.Threading;
 
 [assembly: InternalsVisibleToAttribute("ff-server-sdk-test")]
 
@@ -23,11 +24,15 @@ namespace io.harness.cfsdk.client.api
     internal interface IEvaluator
     {
         bool BoolVariation(string key, Target target, bool defaultValue);
+        Task<bool> BoolVariationAsync(string key, Target target, bool defaultValue, CancellationToken cancellationToken = default);
         string StringVariation(string key, Target target, string defaultValue);
+        Task<string> StringVariationAsync(string key, Target target, string defaultValue, CancellationToken cancellationToken = default);
         double NumberVariation(string key, Target target, double defaultValue);
+        Task<double> NumberVariationAsync(string key, Target target, double defaultValue, CancellationToken cancellationToken = default);
         JToken JsonVariationToken(string key, Target target, JToken defaultValue);
+        Task<JToken> JsonVariationTokenAsync(string key, Target target, JToken defaultValue, CancellationToken cancellationToken = default);
         JObject JsonVariation(string key, Target target, JObject defaultValue);
-
+        Task<JObject> JsonVariationAsync(string key, Target target, JObject defaultValue, CancellationToken cancellationToken = default);
     }
 
     internal class Evaluator : IEvaluator
@@ -55,7 +60,17 @@ namespace io.harness.cfsdk.client.api
 
         public bool BoolVariation(string key, Target target, bool defaultValue)
         {
-            var variation = EvaluateVariation(key, target, FeatureConfigKind.Boolean);
+            return BoolVariationAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        public async Task<bool> BoolVariationAsync(
+            string key,
+            Target target,
+            bool defaultValue,
+            CancellationToken cancellationToken = default)
+        {
+            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.Boolean, cancellationToken);
             bool res;
             if (variation != null && bool.TryParse(variation.Value, out res)) return res;
 
@@ -65,7 +80,17 @@ namespace io.harness.cfsdk.client.api
 
         public JToken JsonVariationToken(string key, Target target, JToken defaultValue)
         {
-            var variation = EvaluateVariation(key, target, FeatureConfigKind.Json);
+            return JsonVariationTokenAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        public async Task<JToken> JsonVariationTokenAsync(
+            string key,
+            Target target,
+            JToken defaultValue,
+            CancellationToken cancellationToken = default)
+        {
+            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.Json, cancellationToken);
             if (variation == null)
             {
                 LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue);
@@ -88,7 +113,17 @@ namespace io.harness.cfsdk.client.api
 
         public JObject JsonVariation(string key, Target target, JObject defaultValue)
         {
-            var variation = EvaluateVariation(key, target, FeatureConfigKind.Json);
+            return JsonVariationAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        public async Task<JObject> JsonVariationAsync(
+            string key,
+            Target target,
+            JObject defaultValue,
+            CancellationToken cancellationToken = default)
+        {
+            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.Json);
             if (variation != null)
             {
                 try
@@ -116,7 +151,17 @@ namespace io.harness.cfsdk.client.api
 
         public double NumberVariation(string key, Target target, double defaultValue)
         {
-            var variation = EvaluateVariation(key, target, FeatureConfigKind.Int);
+            return NumberVariationAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        public async Task<double> NumberVariationAsync(
+            string key,
+            Target target,
+            double defaultValue,
+            CancellationToken cancellationToken = default)
+        {
+            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.Int);
             double res;
             if (variation != null && double.TryParse(variation.Value, out res)) return res;
 
@@ -126,14 +171,28 @@ namespace io.harness.cfsdk.client.api
 
         public string StringVariation(string key, Target target, string defaultValue)
         {
-            var variation = EvaluateVariation(key, target, FeatureConfigKind.String);
+            return StringVariationAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        public async Task<string> StringVariationAsync(
+            string key,
+            Target target,
+            string defaultValue,
+            CancellationToken cancellationToken = default)
+        {
+            var variation = await EvaluateVariationAsync(key, target, FeatureConfigKind.String);
             if (variation != null) return variation.Value;
 
             LogEvaluationFailureError(FeatureConfigKind.String, key, target, defaultValue);
             return defaultValue;
         }
 
-        private Variation EvaluateVariation(string key, Target target, FeatureConfigKind kind)
+        private async Task<Variation> EvaluateVariationAsync(
+            string key,
+            Target target,
+            FeatureConfigKind kind,
+            CancellationToken cancellationToken = default)
         {
             var featureConfig = repository.GetFlag(key);
             if (featureConfig == null)
@@ -145,7 +204,9 @@ namespace io.harness.cfsdk.client.api
 
                 if (poller != null)
                 {
-                    var refreshResult = poller.RefreshFlags(TimeSpan.FromMilliseconds(config.CacheRecoveryTimeoutInMs));
+                    var refreshResult = await poller.RefreshFlagsAsync(
+                        TimeSpan.FromMilliseconds(config.CacheRecoveryTimeoutInMs),
+                        cancellationToken);
 
                     if (refreshResult != RefreshOutcome.Success)
                         return null;

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -21,7 +21,7 @@ namespace io.harness.cfsdk.client.api
         void EvaluationProcessed(FeatureConfig featureConfig, Target target, Variation variation);
     }
 
-    internal interface IEvaluator
+    internal interface IEvaluator: IDisposable
     {
         bool BoolVariation(string key, Target target, bool defaultValue);
         Task<bool> BoolVariationAsync(string key, Target target, bool defaultValue, CancellationToken cancellationToken = default);
@@ -44,6 +44,7 @@ namespace io.harness.cfsdk.client.api
         private readonly IRepository repository;
         private readonly IPollingProcessor poller;
         private readonly Config config;
+        private bool isDisposed = false;
 
 
         public Evaluator(IRepository repository, IEvaluatorCallback callback, ILoggerFactory loggerFactory,
@@ -56,6 +57,27 @@ namespace io.harness.cfsdk.client.api
             IsAnalyticsEnabled = isAnalyticsEnabled;
             this.poller = poller;
             this.config = config;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                poller?.Dispose();
+            }
+
+            isDisposed = true;
         }
 
         public bool BoolVariation(string key, Target target, bool defaultValue)

--- a/client/api/Evaluator.cs
+++ b/client/api/Evaluator.cs
@@ -25,7 +25,7 @@ namespace io.harness.cfsdk.client.api
         bool BoolVariation(string key, Target target, bool defaultValue);
         string StringVariation(string key, Target target, string defaultValue);
         double NumberVariation(string key, Target target, double defaultValue);
-        JToken JsonVariationToken(string key, Target target, JToken defaultValue); 
+        JToken JsonVariationToken(string key, Target target, JToken defaultValue);
         JObject JsonVariation(string key, Target target, JObject defaultValue);
 
     }
@@ -71,7 +71,7 @@ namespace io.harness.cfsdk.client.api
                 LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue);
                 return defaultValue;
             }
-            
+
             try
             {
                 return JToken.Parse(variation.Value);
@@ -85,7 +85,7 @@ namespace io.harness.cfsdk.client.api
             }
 
         }
-        
+
         public JObject JsonVariation(string key, Target target, JObject defaultValue)
         {
             var variation = EvaluateVariation(key, target, FeatureConfigKind.Json);
@@ -95,9 +95,9 @@ namespace io.harness.cfsdk.client.api
                 {
                     var token = JToken.Parse(variation.Value);
                     if (token.Type == JTokenType.Object) return (JObject)token;
-                    
+
                     if (!logger.IsEnabled(LogLevel.Warning)) return defaultValue;
-                    
+
                     logger.LogWarning("JSON variation is not an object. Returning default value. Use JsonVariationToken(string key, Target target, JToken defaultValue) which is available since version 1.7.0");
                     LogEvaluationFailureError(FeatureConfigKind.Json, key, target, defaultValue);
                     return defaultValue;
@@ -145,7 +145,7 @@ namespace io.harness.cfsdk.client.api
 
                 if (poller != null)
                 {
-                    var refreshResult = poller.RefreshFlags(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
+                    var refreshResult = poller.RefreshFlags(TimeSpan.FromMilliseconds(config.CacheRecoveryTimeoutInMs));
 
                     if (refreshResult != RefreshOutcome.Success)
                         return null;
@@ -342,7 +342,7 @@ namespace io.harness.cfsdk.client.api
                         logger.LogDebug(
                             "Percentage rollout applies to group rule, evaluating distribution: Target({@Target}) Flag({@Flag})",
                             new { Target = target}, new { Flag = featureConfig});
-                            
+
 
                     var distributionProcessor = new DistributionProcessor(servingRule.Serve, loggerFactory);
                     return distributionProcessor.loadKeyName(target);
@@ -354,7 +354,7 @@ namespace io.harness.cfsdk.client.api
                     if (logger.IsEnabled(LogLevel.Warning))
                         logger.LogWarning("Serve.Variation is null for a rule in Flag({@FeatureConfig})",
                              new { Flag = featureConfig});
-                        
+
                     return null;
                 }
 
@@ -367,7 +367,7 @@ namespace io.harness.cfsdk.client.api
                     new { Target = target}, new { Flag = featureConfig});
             return null;
         }
-        
+
         private bool IsTargetIncludedOrExcludedInSegment(ICollection<string> segmentList, Target target)
         {
             foreach (var segmentIdentifier in segmentList)

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Target = io.harness.cfsdk.client.dto.Target;
 
@@ -20,7 +21,8 @@ namespace io.harness.cfsdk.client.api
         IPollCallback,
         IUpdateCallback,
         IEvaluatorCallback,
-        IConnectionCallback
+        IConnectionCallback,
+        IDisposable
     {
         private ILoggerFactory loggerFactory;
         private ILogger logger;
@@ -34,6 +36,7 @@ namespace io.harness.cfsdk.client.api
         private MetricsProcessor metric;
         private IConnector connector;
         private Config config;
+        private bool isDisposed = false;
 
         public event EventHandler InitializationCompleted;
         public event EventHandler<string> EvaluationChanged;
@@ -41,12 +44,12 @@ namespace io.harness.cfsdk.client.api
 
         private readonly CfClient parent;
         private readonly CountdownEvent sdkReadyLatch = new(1);
-        
+
         // Use property SdkInitialized for thread-safe access 
         private int sdkInitialized;
 
-        private bool SdkInitialized 
-        { 
+        private bool SdkInitialized
+        {
             get => Interlocked.CompareExchange(ref sdkInitialized, 0, 0) == 1;
             set => Interlocked.Exchange(ref sdkInitialized, value ? 1 : 0);
         }
@@ -151,7 +154,7 @@ namespace io.harness.cfsdk.client.api
             logger.LogInformation("SDKCODE(init:1000): The SDK has successfully initialized");
             logger.LogInformation("SDK version: " + Assembly.GetExecutingAssembly().GetName().Version);
         }
-        
+
         public void OnAuthenticationFailure()
         {
             SdkInitialized = false;
@@ -223,7 +226,7 @@ namespace io.harness.cfsdk.client.api
         {
             OnNotifyFlagsLoaded(identifiers);
         }
-        
+
         public void OnFlagDeleted(string identifier)
         {
             OnNotifyEvaluationChanged(identifier);
@@ -252,195 +255,173 @@ namespace io.harness.cfsdk.client.api
         {
             EvaluationChanged?.Invoke(parent, identifier);
         }
-        
+
         private void OnNotifyFlagsLoaded(IList<string> identifiers)
         {
             FlagsLoaded?.Invoke(parent, identifiers);
         }
 
-        public bool BoolVariation(string key, Target target, bool defaultValue)
+        /// <summary>
+        /// Centralized method to handle variation retrieval with cache state validation and recovery logic.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the variation value.</typeparam>
+        /// <param name="variationFunc">The function to retrieve the variation value.</param>
+        /// <param name="kind">The kind of feature flag.</param>
+        /// <param name="key">The key of the feature flag.</param>
+        /// <param name="target">The target for which the variation is evaluated.</param>
+        /// <param name="defaultValue">The default value to return if evaluation fails.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The evaluated variation value or the default value if evaluation fails.</returns>
+        private async Task<TValue> RetrieveValue<TValue>(
+            Func<TValue> variationFunc,
+            FeatureConfigKind kind,
+            string key,
+            Target target,
+            TValue defaultValue,
+            CancellationToken cancellationToken)
         {
-            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.Boolean, key, target, defaultValue);
+            if (!SdkInitialized) return LogAndReturnDefault(kind, key, target, defaultValue);
 
             try
             {
-                return evaluator.BoolVariation(key, target, defaultValue);
+                return variationFunc();
             }
             catch (InvalidCacheStateException ex)
             {
                 logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating boolean variation for flag {Key}, refreshing cache and retrying evaluation ",
-                    key);
+                    "Invalid cache state detected when evaluating {Kind} variation for flag {Key}, refreshing cache and retrying evaluation",
+                    kind, key);
 
-                var result = polling.RefreshFlagsAndSegments(TimeSpan.FromMilliseconds(2000));
+                var timeout = TimeSpan.FromMilliseconds(config.CacheRecoveryTimeoutInMs);
+                var result = await polling.RefreshFlagsAndSegmentsAsync(timeout, cancellationToken);
 
                 if (result != RefreshOutcome.Success)
                 {
                     logger.LogError(ex,
-                        "Refreshing cache for boolean variation for flag {Key} failed, returning default variation ",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.Boolean, key, target, defaultValue);
+                        "Refreshing cache for {Kind} variation for flag {Key} failed, returning default variation",
+                        kind, key);
+                    return LogAndReturnDefault(kind, key, target, defaultValue);
                 }
 
                 try
                 {
-                    return evaluator.BoolVariation(key, target, defaultValue);
+                    return variationFunc();
                 }
-                catch (InvalidCacheStateException)
+                catch (InvalidCacheStateException cex)
                 {
-                    logger.LogWarning(
-                        "Attempted re-evaluation of boolean variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.Boolean, key, target, defaultValue);
+                    logger.LogWarning(cex,
+                        "Attempted re-evaluation of {Kind} variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
+                        kind, key);
+                    return LogAndReturnDefault(kind, key, target, defaultValue);
                 }
             }
+        }
+
+        public bool BoolVariation(string key, Target target, bool defaultValue)
+        {
+            return BoolVariationAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        public async Task<bool> BoolVariationAsync(string key, Target target, bool defaultValue, CancellationToken cancellationToken)
+        {
+            return await RetrieveValue(
+                () => evaluator.BoolVariation(key, target, defaultValue),
+                FeatureConfigKind.Boolean,
+                key,
+                target,
+                defaultValue,
+                cancellationToken);
         }
 
         public string StringVariation(string key, Target target, string defaultValue)
         {
-            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.String, key, target, defaultValue);
+            return StringVariationAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
 
-            try
-            {
-                return evaluator.StringVariation(key, target, defaultValue);
-            }
-            catch (InvalidCacheStateException ex)
-            {
-                logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating string variation for flag {Key}, refreshing cache and retrying evaluation",
-                    key);
-
-                var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
-                if (result != RefreshOutcome.Success)
-                {
-                    logger.LogError(
-                        "Refreshing cache for string variation for flag {Key} failed, returning default variation",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.String, key, target, defaultValue);
-                }
-
-                try
-                {
-                    return evaluator.StringVariation(key, target, defaultValue);
-                }
-                catch (InvalidCacheStateException)
-                {
-                    logger.LogWarning(
-                        "Attempted re-evaluation of string variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.String, key, target, defaultValue);
-                }
-            }
+        public async Task<string> StringVariationAsync(string key, Target target, string defaultValue, CancellationToken cancellationToken)
+        {
+            return await RetrieveValue(
+                () => evaluator.StringVariation(key, target, defaultValue),
+                FeatureConfigKind.String,
+                key,
+                target,
+                defaultValue,
+                cancellationToken);
         }
 
         public double NumberVariation(string key, Target target, double defaultValue)
         {
-            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.Int, key, target, defaultValue);
+            return NumberVariationAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
 
-            try
-            {
-                return evaluator.NumberVariation(key, target, defaultValue);
-            }
-            catch (InvalidCacheStateException ex)
-            {
-                logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating number variation for flag {Key}, refreshing cache and retrying evaluation",
-                    key);
-                var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
-                if (result != RefreshOutcome.Success)
-                {
-                    logger.LogError(
-                        "Refreshing cache for number variation for flag {Key} failed, returning default variation",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.Int, key, target, defaultValue);
-                }
-
-                try
-                {
-                    return evaluator.NumberVariation(key, target, defaultValue);
-                }
-                catch (InvalidCacheStateException)
-                {
-                    logger.LogWarning(
-                        "Attempted re-evaluation of number variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.Int, key, target, defaultValue);
-                }
-            }
+        public async Task<double> NumberVariationAsync(string key, Target target, double defaultValue, CancellationToken cancellationToken)
+        {
+            return await RetrieveValue(
+                () => evaluator.NumberVariation(key, target, defaultValue),
+                FeatureConfigKind.Int,
+                key,
+                target,
+                defaultValue,
+                cancellationToken);
         }
 
         public JToken JsonVariationToken(string key, Target target, JToken defaultValue)
         {
-            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
+            return JsonVariationTokenAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
 
-            try
-            {
-                return evaluator.JsonVariationToken(key, target, defaultValue);
-            }
-            catch (InvalidCacheStateException ex)
-            {
-                logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
-                    key);
-                var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
-                if (result != RefreshOutcome.Success)
-                {
-                    logger.LogError(
-                        "Refreshing cache for json variation for flag {Key} failed, returning default variation",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
-                }
-
-                try
-                {
-                    return evaluator.JsonVariationToken(key, target, defaultValue);
-                }
-                catch (InvalidCacheStateException)
-                {
-                    logger.LogWarning(
-                        "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
-                }
-            }
+        public async Task<JToken> JsonVariationTokenAsync(string key, Target target, JToken defaultValue, CancellationToken cancellationToken)
+        {
+            return await RetrieveValue(
+                () => evaluator.JsonVariationToken(key, target, defaultValue),
+                FeatureConfigKind.Json,
+                key,
+                target,
+                defaultValue,
+                cancellationToken);
         }
 
         public JObject JsonVariation(string key, Target target, JObject defaultValue)
         {
-            if (!SdkInitialized) return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
-
-            try
-            {
-                return evaluator.JsonVariation(key, target, defaultValue);
-            }
-            catch (InvalidCacheStateException ex)
-            {
-                logger.LogWarning(ex,
-                    "Invalid cache state detected when evaluating json variation for flag {Key}, refreshing cache and retrying evaluation",
-                    key);
-                var result = polling.RefreshFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
-                if (result != RefreshOutcome.Success)
-                {
-                    logger.LogError(
-                        "Refreshing cache for json variation for flag {Key} failed, returning default variation",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
-                }
-
-                try
-                {
-                    return evaluator.JsonVariation(key, target, defaultValue);
-                }
-                catch (InvalidCacheStateException)
-                {
-                    logger.LogWarning(
-                        "Attempted re-evaluation of json variation for flag {Key} after refreshing cache failed due to invalid cache state, returning default variation",
-                        key);
-                    return LogAndReturnDefault(FeatureConfigKind.Json, key, target, defaultValue);
-                }
-            }
+            return JsonVariationAsync(key, target, defaultValue, CancellationToken.None)
+                .GetAwaiter().GetResult();
         }
 
+        public async Task<JObject> JsonVariationAsync(string key, Target target, JObject defaultValue, CancellationToken cancellationToken)
+        {
+            return await RetrieveValue(
+                () => evaluator.JsonVariation(key, target, defaultValue),
+                FeatureConfigKind.Json,
+                key,
+                target,
+                defaultValue,
+                cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                Close();
+            }
+
+            isDisposed = true;
+        }
 
         public void Close()
         {
@@ -462,7 +443,7 @@ namespace io.harness.cfsdk.client.api
         {
             this.metric.PushToCache(target, featureConfig, variation);
         }
-        
+
         private T LogAndReturnDefault<T>(FeatureConfigKind kind, string key, Target target, T defaultValue)
         {
             LogEvaluationFailureError(kind, key, target, defaultValue?.ToString() ?? "null");

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -320,7 +320,7 @@ namespace io.harness.cfsdk.client.api
         public bool BoolVariation(string key, Target target, bool defaultValue)
         {
             return BoolVariationAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<bool> BoolVariationAsync(string key, Target target, bool defaultValue, CancellationToken cancellationToken)
@@ -337,7 +337,7 @@ namespace io.harness.cfsdk.client.api
         public string StringVariation(string key, Target target, string defaultValue)
         {
             return StringVariationAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<string> StringVariationAsync(string key, Target target, string defaultValue, CancellationToken cancellationToken)
@@ -354,7 +354,7 @@ namespace io.harness.cfsdk.client.api
         public double NumberVariation(string key, Target target, double defaultValue)
         {
             return NumberVariationAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<double> NumberVariationAsync(string key, Target target, double defaultValue, CancellationToken cancellationToken)
@@ -371,7 +371,7 @@ namespace io.harness.cfsdk.client.api
         public JToken JsonVariationToken(string key, Target target, JToken defaultValue)
         {
             return JsonVariationTokenAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<JToken> JsonVariationTokenAsync(string key, Target target, JToken defaultValue, CancellationToken cancellationToken)
@@ -388,7 +388,7 @@ namespace io.harness.cfsdk.client.api
         public JObject JsonVariation(string key, Target target, JObject defaultValue)
         {
             return JsonVariationAsync(key, target, defaultValue, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<JObject> JsonVariationAsync(string key, Target target, JObject defaultValue, CancellationToken cancellationToken)

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -273,7 +273,7 @@ namespace io.harness.cfsdk.client.api
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The evaluated variation value or the default value if evaluation fails.</returns>
         private async Task<TValue> RetrieveValue<TValue>(
-            Func<TValue> variationFunc,
+            Func<Task<TValue>> variationFunc,
             FeatureConfigKind kind,
             string key,
             Target target,
@@ -284,7 +284,7 @@ namespace io.harness.cfsdk.client.api
 
             try
             {
-                return variationFunc();
+                return await variationFunc();
             }
             catch (InvalidCacheStateException ex)
             {
@@ -305,7 +305,7 @@ namespace io.harness.cfsdk.client.api
 
                 try
                 {
-                    return variationFunc();
+                    return await variationFunc();
                 }
                 catch (InvalidCacheStateException cex)
                 {
@@ -326,7 +326,7 @@ namespace io.harness.cfsdk.client.api
         public async Task<bool> BoolVariationAsync(string key, Target target, bool defaultValue, CancellationToken cancellationToken)
         {
             return await RetrieveValue(
-                () => evaluator.BoolVariation(key, target, defaultValue),
+                async () => await evaluator.BoolVariationAsync(key, target, defaultValue, cancellationToken),
                 FeatureConfigKind.Boolean,
                 key,
                 target,
@@ -343,7 +343,7 @@ namespace io.harness.cfsdk.client.api
         public async Task<string> StringVariationAsync(string key, Target target, string defaultValue, CancellationToken cancellationToken)
         {
             return await RetrieveValue(
-                () => evaluator.StringVariation(key, target, defaultValue),
+                async () => await evaluator.StringVariationAsync(key, target, defaultValue),
                 FeatureConfigKind.String,
                 key,
                 target,
@@ -360,7 +360,7 @@ namespace io.harness.cfsdk.client.api
         public async Task<double> NumberVariationAsync(string key, Target target, double defaultValue, CancellationToken cancellationToken)
         {
             return await RetrieveValue(
-                () => evaluator.NumberVariation(key, target, defaultValue),
+                async () => await evaluator.NumberVariationAsync(key, target, defaultValue),
                 FeatureConfigKind.Int,
                 key,
                 target,
@@ -377,7 +377,7 @@ namespace io.harness.cfsdk.client.api
         public async Task<JToken> JsonVariationTokenAsync(string key, Target target, JToken defaultValue, CancellationToken cancellationToken)
         {
             return await RetrieveValue(
-                () => evaluator.JsonVariationToken(key, target, defaultValue),
+                async () => await evaluator.JsonVariationTokenAsync(key, target, defaultValue),
                 FeatureConfigKind.Json,
                 key,
                 target,
@@ -394,7 +394,7 @@ namespace io.harness.cfsdk.client.api
         public async Task<JObject> JsonVariationAsync(string key, Target target, JObject defaultValue, CancellationToken cancellationToken)
         {
             return await RetrieveValue(
-                () => evaluator.JsonVariation(key, target, defaultValue),
+                async () => await evaluator.JsonVariationAsync(key, target, defaultValue),
                 FeatureConfigKind.Json,
                 key,
                 target,

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -343,7 +343,7 @@ namespace io.harness.cfsdk.client.api
         public async Task<string> StringVariationAsync(string key, Target target, string defaultValue, CancellationToken cancellationToken)
         {
             return await RetrieveValue(
-                async () => await evaluator.StringVariationAsync(key, target, defaultValue),
+                async () => await evaluator.StringVariationAsync(key, target, defaultValue, cancellationToken),
                 FeatureConfigKind.String,
                 key,
                 target,
@@ -360,7 +360,7 @@ namespace io.harness.cfsdk.client.api
         public async Task<double> NumberVariationAsync(string key, Target target, double defaultValue, CancellationToken cancellationToken)
         {
             return await RetrieveValue(
-                async () => await evaluator.NumberVariationAsync(key, target, defaultValue),
+                async () => await evaluator.NumberVariationAsync(key, target, defaultValue, cancellationToken),
                 FeatureConfigKind.Int,
                 key,
                 target,
@@ -377,7 +377,7 @@ namespace io.harness.cfsdk.client.api
         public async Task<JToken> JsonVariationTokenAsync(string key, Target target, JToken defaultValue, CancellationToken cancellationToken)
         {
             return await RetrieveValue(
-                async () => await evaluator.JsonVariationTokenAsync(key, target, defaultValue),
+                async () => await evaluator.JsonVariationTokenAsync(key, target, defaultValue, cancellationToken),
                 FeatureConfigKind.Json,
                 key,
                 target,
@@ -394,7 +394,7 @@ namespace io.harness.cfsdk.client.api
         public async Task<JObject> JsonVariationAsync(string key, Target target, JObject defaultValue, CancellationToken cancellationToken)
         {
             return await RetrieveValue(
-                async () => await evaluator.JsonVariationAsync(key, target, defaultValue),
+                async () => await evaluator.JsonVariationAsync(key, target, defaultValue, cancellationToken),
                 FeatureConfigKind.Json,
                 key,
                 target,

--- a/client/api/InnerClient.cs
+++ b/client/api/InnerClient.cs
@@ -428,7 +428,8 @@ namespace io.harness.cfsdk.client.api
             this.connector?.Close();
             this.authService?.Stop();
             this.repository?.Close();
-            this.polling?.Stop();
+            this.evaluator?.Dispose();
+            this.polling?.Dispose();
             this.update?.Stop();
             this.metric?.Stop();
             this.SdkInitialized = false;

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -102,33 +102,6 @@ namespace io.harness.cfsdk.client.api
             isDisposed = true;
         }
 
-        private static async Task RunWithTimeout(Task task, TimeSpan timeout, CancellationToken cancellationToken = default)
-        {
-            var tasks = new List<Task>();
-            if (task != null)
-            {
-                tasks.Add(task);
-            }
-
-            await RunWithTimeout(tasks, timeout, cancellationToken);
-        }
-
-        private static async Task RunWithTimeout(IEnumerable<Task> tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
-        {
-            var allTasks = Task.WhenAll(tasks);
-
-#if NET6_0_OR_GREATER
-            await allTasks.WaitAsync(timeout, cancellationToken);
-#else
-            var timeoutTask = Task.Delay(timeout, cancellationToken);
-            var completedTask = await Task.WhenAny(allTasks, timeoutTask);
-            if (completedTask == timeoutTask)
-            {
-                throw new TimeoutException();
-            }
-#endif
-        }
-
         public void Start()
         {
             var intervalMs = config.PollIntervalInMiliSeconds;
@@ -190,7 +163,8 @@ namespace io.harness.cfsdk.client.api
 
         private async Task ProcessFlags(TimeSpan timeout, CancellationToken cancellationToken = default)
         {
-            await RunWithTimeout(ProcessFlags(), timeout, cancellationToken);
+            await ProcessFlags()
+                .RunWithTimeout(timeout, cancellationToken);
         }
 
         private async Task ProcessSegments()
@@ -215,16 +189,20 @@ namespace io.harness.cfsdk.client.api
 
         private async Task ProcessSegments(TimeSpan timeout, CancellationToken cancellationToken = default)
         {
-            await RunWithTimeout(ProcessSegments(), timeout, cancellationToken);
+            await ProcessSegments()
+                .RunWithTimeout(timeout, cancellationToken);
         }
 
         private async Task ProcessFlagsAndSegments(TimeSpan timeout, CancellationToken cancellationToken = default)
         {
             // Await both tasks to complete within the timeout
-            await RunWithTimeout(
-                new List<Task> { ProcessFlags(), ProcessSegments() },
-                timeout,
-                cancellationToken);
+            var tasks = new List<Task>
+            {
+                ProcessFlags(),
+                ProcessSegments()
+            };
+            await tasks
+                .RunWithTimeout(timeout, cancellationToken);
         }
 
         public RefreshOutcome RefreshFlagsAndSegments(TimeSpan timeout)

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -120,7 +120,7 @@ namespace io.harness.cfsdk.client.api
             try
             {
                 ProcessFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs))
-                    .GetAwaiter().GetResult();
+                    .ConfigureAwait(false).GetAwaiter().GetResult();
             }
             catch (TimeoutException ex)
             {
@@ -206,7 +206,7 @@ namespace io.harness.cfsdk.client.api
         public RefreshOutcome RefreshFlagsAndSegments(TimeSpan timeout)
         {
             return RefreshFlagsAndSegmentsAsync(timeout, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<RefreshOutcome> RefreshFlagsAndSegmentsAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -245,7 +245,7 @@ namespace io.harness.cfsdk.client.api
         public RefreshOutcome RefreshSegments(TimeSpan timeout)
         {
             return RefreshSegmentsAsync(timeout, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<RefreshOutcome> RefreshSegmentsAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
@@ -283,7 +283,7 @@ namespace io.harness.cfsdk.client.api
         public RefreshOutcome RefreshFlags(TimeSpan timeout)
         {
             return RefreshFlagsAsync(timeout, CancellationToken.None)
-                .GetAwaiter().GetResult();
+                .ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public async Task<RefreshOutcome> RefreshFlagsAsync(TimeSpan timeout, CancellationToken cancellationToken = default)

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -28,7 +28,7 @@ namespace io.harness.cfsdk.client.api
         void OnPollCompleted();
     }
 
-    internal interface IPollingProcessor
+    internal interface IPollingProcessor: IDisposable
     {
         /// <summary>
         /// Stop pooling
@@ -67,6 +67,7 @@ namespace io.harness.cfsdk.client.api
         private DateTime lastFlagsRefreshTime = DateTime.MinValue;
         private DateTime lastSegmentsRefreshTime = DateTime.MinValue;
         private const int MaxCacheRefreshTime = 60;
+        private bool isDisposed = false;
 
         private readonly TimeSpan refreshCooldown = TimeSpan.FromSeconds(MaxCacheRefreshTime);
 
@@ -77,6 +78,28 @@ namespace io.harness.cfsdk.client.api
             this.connector = connector;
             this.config = config;
             this.logger = loggerFactory.CreateLogger<PollingProcessor>();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                Stop();
+                cacheRefreshLock.Dispose();
+            }
+                
+            isDisposed = true;
         }
 
         private static Task RunWithTimeout(Task task, TimeSpan timeout, CancellationToken cancellationToken = default)

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -15,7 +15,7 @@ namespace io.harness.cfsdk.client.api
         Error,
         TooSoon,
     }
-    
+
     internal interface IPollCallback
     {
         /// <summary>
@@ -40,9 +40,11 @@ namespace io.harness.cfsdk.client.api
         void Start();
 
         RefreshOutcome RefreshSegments(TimeSpan timeout);
+        Task<RefreshOutcome> RefreshSegmentsAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
         RefreshOutcome RefreshFlags(TimeSpan timeout);
-    
+        Task<RefreshOutcome> RefreshFlagsAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
         RefreshOutcome RefreshFlagsAndSegments(TimeSpan timeout);
+        Task<RefreshOutcome> RefreshFlagsAndSegmentsAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
 
     }
 
@@ -61,9 +63,9 @@ namespace io.harness.cfsdk.client.api
         private readonly Config config;
         private Timer pollTimer;
         private bool isInitialized = false;
-        private readonly object cacheRefreshLock = new object();
+        private readonly SemaphoreSlim cacheRefreshLock = new SemaphoreSlim(1, 1);
         private DateTime lastFlagsRefreshTime = DateTime.MinValue;
-        private DateTime lastSegmentsRefreshTime = DateTime.MinValue;       
+        private DateTime lastSegmentsRefreshTime = DateTime.MinValue;
         private const int MaxCacheRefreshTime = 60;
 
         private readonly TimeSpan refreshCooldown = TimeSpan.FromSeconds(MaxCacheRefreshTime);
@@ -75,6 +77,32 @@ namespace io.harness.cfsdk.client.api
             this.connector = connector;
             this.config = config;
             this.logger = loggerFactory.CreateLogger<PollingProcessor>();
+        }
+
+        private static Task RunWithTimeout(Task task, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            var tasks = new List<Task>();
+            if (task != null)
+            {
+                tasks.Add(task);
+            }
+
+            return RunWithTimeout(tasks, timeout, cancellationToken);
+        }
+
+        private static Task RunWithTimeout(IEnumerable<Task> tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            var timeoutTask = Task.Delay(timeout, cancellationToken);
+            var allTasks = Task.WhenAll(tasks);
+            return Task.WhenAny(allTasks, timeoutTask)
+                .ContinueWith(t =>
+                {
+                    if (t.Result == timeoutTask)
+                    {
+                        throw new TimeoutException();
+                    }
+                    return allTasks;
+                }, cancellationToken).Unwrap();
         }
 
         public void Start()
@@ -91,7 +119,12 @@ namespace io.harness.cfsdk.client.api
 
             try
             {
-                Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() }).Wait();
+                ProcessFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs))
+                    .GetAwaiter().GetResult();
+            }
+            catch (TimeoutException ex)
+            {
+                logger.LogWarning(ex, "First poll did not complete within the specified timeout");
             }
             catch (Exception ex)
             {
@@ -119,8 +152,10 @@ namespace io.harness.cfsdk.client.api
                 var flags = await this.connector.GetFlags();
                 logger.LogDebug("Fetching flags finished");
                 repository.SetFlags(flags);
-                logger.LogDebug("Loaded {SegmentRuleCount} flags", flags.Count());
-
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.LogDebug("Loaded {SegmentRuleCount} flags", flags.Count());
+                }
             }
             catch (Exception ex)
             {
@@ -128,6 +163,12 @@ namespace io.harness.cfsdk.client.api
                 throw;
             }
         }
+
+        private async Task ProcessFlags(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            await RunWithTimeout(ProcessFlags(), timeout, cancellationToken);
+        }
+
         private async Task ProcessSegments()
         {
             try
@@ -136,7 +177,10 @@ namespace io.harness.cfsdk.client.api
                 IEnumerable<Segment> segments = await connector.GetSegments();
                 logger.LogDebug("Fetching segments finished");
                 repository.SetSegments(segments);
-                logger.LogDebug("Loaded {SegmentRuleCount} groups", segments.Count());
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.LogDebug("Loaded {SegmentRuleCount} groups", segments.Count());
+                }
             }
             catch (Exception ex)
             {
@@ -145,9 +189,31 @@ namespace io.harness.cfsdk.client.api
             }
         }
 
+        private async Task ProcessSegments(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            await RunWithTimeout(ProcessSegments(), timeout, cancellationToken);
+        }
+
+        private async Task ProcessFlagsAndSegments(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            // Await both tasks to complete within the timeout
+            await RunWithTimeout(
+                new List<Task> { ProcessFlags(), ProcessSegments() },
+                timeout,
+                cancellationToken);
+        }
+
         public RefreshOutcome RefreshFlagsAndSegments(TimeSpan timeout)
         {
-            lock (cacheRefreshLock)
+            return RefreshFlagsAndSegmentsAsync(timeout, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        public async Task<RefreshOutcome> RefreshFlagsAndSegmentsAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            await cacheRefreshLock.WaitAsync(cancellationToken);
+
+            try
             {
                 if (!CanRefreshCache(ref lastSegmentsRefreshTime))
                 {
@@ -155,33 +221,38 @@ namespace io.harness.cfsdk.client.api
                     return RefreshOutcome.TooSoon;
                 }
 
-                var processSegmentsTask = Task.Run(async () => await ProcessSegments());
-                var processFlagsTask = Task.Run(async () => await ProcessFlags());
+                await ProcessFlagsAndSegments(timeout, cancellationToken);
 
-                try
-                {
-                    // Await both tasks to complete within the timeout
-                    var refreshSuccessful = Task.WaitAll(new[] { processSegmentsTask, processFlagsTask }, timeout);
-                    if (refreshSuccessful)
-                    {
-                        UpdateLastRefreshTime(ref lastSegmentsRefreshTime);
-                        return RefreshOutcome.Success;
-                    }
-
-                    logger.LogWarning("Refreshing flags and groups did not complete within the specified timeout");
-                    return RefreshOutcome.Error;
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Exception occurred while refreshing flags and groups");
-                    return RefreshOutcome.Error;
-                }
+                UpdateLastRefreshTime(ref lastSegmentsRefreshTime);
+                return RefreshOutcome.Success;
+            }
+            catch (TimeoutException ex)
+            {
+                logger.LogWarning(ex, "Refreshing flags and groups did not complete within the specified timeout");
+                return RefreshOutcome.Error;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Exception occurred while refreshing flags and groups");
+                return RefreshOutcome.Error;
+            }
+            finally
+            {
+                cacheRefreshLock.Release();
             }
         }
 
         public RefreshOutcome RefreshSegments(TimeSpan timeout)
         {
-            lock (cacheRefreshLock)
+            return RefreshSegmentsAsync(timeout, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        public async Task<RefreshOutcome> RefreshSegmentsAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            await cacheRefreshLock.WaitAsync(cancellationToken);
+
+            try
             {
                 if (!CanRefreshCache(ref lastSegmentsRefreshTime))
                 {
@@ -189,74 +260,81 @@ namespace io.harness.cfsdk.client.api
                     return RefreshOutcome.TooSoon;
                 }
 
-                try
-                {
-                    var task = Task.Run(async () => await ProcessSegments());
-                    var refreshSuccessful = task.Wait(timeout);
-                    if (refreshSuccessful)
-                    {
-                        UpdateLastRefreshTime(ref lastSegmentsRefreshTime);
-                        return RefreshOutcome.Success;
-                    }
-
-                    logger.LogWarning("Refresh groups did not complete within the specified timeout");
-                    return RefreshOutcome.Error;
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Exception occurred while trying to refresh groups");
-                    return RefreshOutcome.Error;
-                }
+                await ProcessSegments(timeout, cancellationToken);
+                UpdateLastRefreshTime(ref lastSegmentsRefreshTime);
+                return RefreshOutcome.Success;
+            }
+            catch (TimeoutException ex)
+            {
+                logger.LogWarning(ex, "Refresh groups did not complete within the specified timeout");
+                return RefreshOutcome.Error;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Exception occurred while trying to refresh groups");
+                return RefreshOutcome.Error;
+            }
+            finally
+            {
+                cacheRefreshLock.Release();
             }
         }
 
         public RefreshOutcome RefreshFlags(TimeSpan timeout)
         {
-            lock (cacheRefreshLock)
+            return RefreshFlagsAsync(timeout, CancellationToken.None)
+                .GetAwaiter().GetResult();
+        }
+
+        public async Task<RefreshOutcome> RefreshFlagsAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            await cacheRefreshLock.WaitAsync(cancellationToken);
+
+            try
             {
                 if (!CanRefreshCache(ref lastFlagsRefreshTime))
                 {
                     logger.LogWarning("Attempt to refresh flags too soon after the last refresh");
                     return RefreshOutcome.TooSoon;
                 }
-                try
-                {
-                    var task = Task.Run(async () => await ProcessFlags());
-                    var refreshSuccessful = task.Wait(timeout);
-                    if (refreshSuccessful)
-                    {
-                        UpdateLastRefreshTime(ref lastFlagsRefreshTime);
-                        return RefreshOutcome.Success;
-                    }
 
-                    logger.LogWarning("RefreshFlags did not complete within the specified timeout");
-                    return RefreshOutcome.Error;
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError(ex, "Exception occurred while trying to refresh flags");
-                    return RefreshOutcome.Error;
-                }
+                await ProcessFlags(timeout, cancellationToken);
+                UpdateLastRefreshTime(ref lastFlagsRefreshTime);
+                return RefreshOutcome.Success;
+            }
+            catch (TimeoutException ex)
+            {
+                logger.LogWarning(ex, "RefreshFlags did not complete within the specified timeout");
+                return RefreshOutcome.Error;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Exception occurred while trying to refresh flags");
+                return RefreshOutcome.Error;
+            }
+            finally
+            {
+                cacheRefreshLock.Release();
             }
         }
 
-   private bool CanRefreshCache(ref DateTime lastRefreshTime)
-    {
-        return (DateTime.UtcNow - lastRefreshTime) >= refreshCooldown;
-    }
+        private bool CanRefreshCache(ref DateTime lastRefreshTime)
+        {
+            return (DateTime.UtcNow - lastRefreshTime) >= refreshCooldown;
+        }
 
-    private void UpdateLastRefreshTime(ref DateTime lastRefreshTime)
-    {
-        lastRefreshTime = DateTime.UtcNow;
-    }
+        private static void UpdateLastRefreshTime(ref DateTime lastRefreshTime)
+        {
+            lastRefreshTime = DateTime.UtcNow;
+        }
 
-        
+
         private async void OnTimedEventAsync(object source)
         {
             try
             {
                 logger.LogDebug("Running polling iteration");
-                await Task.WhenAll(new List<Task> { ProcessFlags(), ProcessSegments() });
+                await ProcessFlagsAndSegments(TimeSpan.FromSeconds(config.CacheRecoveryTimeoutInMs));
                 callback.OnPollCompleted();
                 if (isInitialized) return;
                 isInitialized = true;

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -115,18 +115,18 @@ namespace io.harness.cfsdk.client.api
 
         private static async Task RunWithTimeout(IEnumerable<Task> tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
         {
-            var timeoutTask = Task.Delay(timeout, cancellationToken);
             var allTasks = Task.WhenAll(tasks);
-            
-            await Task.WhenAny(allTasks, timeoutTask)
-                .ContinueWith(t =>
-                {
-                    if (t.Result == timeoutTask)
-                    {
-                        throw new TimeoutException();
-                    }
-                    return allTasks;
-                }, cancellationToken).Unwrap();
+
+#if NET6_0_OR_GREATER
+            await allTasks.WaitAsync(timeout, cancellationToken);
+#else
+            var timeoutTask = Task.Delay(timeout, cancellationToken);
+            var completedTask = await Task.WhenAny(allTasks, timeoutTask);
+            if (completedTask == timeoutTask)
+            {
+                throw new TimeoutException();
+            }
+#endif
         }
 
         public void Start()

--- a/client/api/PollingProcessor.cs
+++ b/client/api/PollingProcessor.cs
@@ -102,7 +102,7 @@ namespace io.harness.cfsdk.client.api
             isDisposed = true;
         }
 
-        private static Task RunWithTimeout(Task task, TimeSpan timeout, CancellationToken cancellationToken = default)
+        private static async Task RunWithTimeout(Task task, TimeSpan timeout, CancellationToken cancellationToken = default)
         {
             var tasks = new List<Task>();
             if (task != null)
@@ -110,14 +110,15 @@ namespace io.harness.cfsdk.client.api
                 tasks.Add(task);
             }
 
-            return RunWithTimeout(tasks, timeout, cancellationToken);
+            await RunWithTimeout(tasks, timeout, cancellationToken);
         }
 
-        private static Task RunWithTimeout(IEnumerable<Task> tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
+        private static async Task RunWithTimeout(IEnumerable<Task> tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
         {
             var timeoutTask = Task.Delay(timeout, cancellationToken);
             var allTasks = Task.WhenAll(tasks);
-            return Task.WhenAny(allTasks, timeoutTask)
+            
+            await Task.WhenAny(allTasks, timeoutTask)
                 .ContinueWith(t =>
                 {
                     if (t.Result == timeoutTask)

--- a/client/connector/EventSource.cs
+++ b/client/connector/EventSource.cs
@@ -72,10 +72,18 @@ namespace io.harness.cfsdk.client.connector
             }
         }
 
+        private async Task<HttpResponseMessage> GetStreamResponse()
+        {
+            var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationTokenSource.Token);
+            response.EnsureSuccessStatusCode();
+            return response;
+        }
+
         private async Task StartStreaming()
         {
             var retryCount = 0;
-            while (!cancellationTokenSource.Token.IsCancellationRequested)
+            var token = cancellationTokenSource.Token;
+            while (!token.IsCancellationRequested)
             {
                 try
                 {
@@ -83,36 +91,15 @@ namespace io.harness.cfsdk.client.connector
 
                     logger.LogDebug("Starting EventSource service");
                     
-                    // In .NET 4.8, we can't use a traditional HTTP Client timeout, or cacncellation token, 
-                    // as the HTTP client interprets reading from the stream as the connection is still open. 
-                    // We use this workaround instead to simulate a timeout for the initial request.
-                    var initialTask = Task.Run(async () =>
-                    {
-                        await Task.Delay(InitialConnectionTimeoutMs, cancellationTokenSource.Token);
-                        throw new TimeoutException("Initial connection timeout");
-                    });
-
-                    var requestTask = Task.Run(async () =>
-                    {
-                        var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationTokenSource.Token);
-                        response.EnsureSuccessStatusCode();
-                        return response;
-                    });
-
-                    var completedTask = await Task.WhenAny(initialTask, requestTask);
-
-                    if (completedTask == initialTask)
-                    {
-                        await initialTask; 
-                    }
-                    
-                    using (Stream stream = await this.httpClient.GetStreamAsync(url))
+                    var timeout = TimeSpan.FromMilliseconds(InitialConnectionTimeoutMs);
+                    using (var response = await GetStreamResponse().RunWithTimeout(timeout, token))
+                    using (var stream = await this.httpClient.GetStreamAsync(url))
                     {
                         retryCount = 0;
                         callback.OnStreamConnected();
 
                         string message;
-                        while ((message = ReadLine(stream, ReadTimeoutMs)) != null && !cancellationTokenSource.Token.IsCancellationRequested)
+                        while ((message = ReadLine(stream, ReadTimeoutMs)) != null && !token.IsCancellationRequested)
                         {
                             if (!message.Contains("domain"))
                             {
@@ -140,7 +127,7 @@ namespace io.harness.cfsdk.client.connector
                 }
                 catch (Exception e)
                 {
-                    if (cancellationTokenSource.Token.IsCancellationRequested)
+                    if (token.IsCancellationRequested)
                     {
                         logger.LogInformation("SDKCODE(stream:5004): SSE thread exited");
                         return;
@@ -159,7 +146,7 @@ namespace io.harness.cfsdk.client.connector
                 }
                 finally
                 {
-                    if (!cancellationTokenSource.Token.IsCancellationRequested)
+                    if (!token.IsCancellationRequested)
                     {
                         callback.OnStreamDisconnected();
                     }

--- a/client/dto/Target.cs
+++ b/client/dto/Target.cs
@@ -75,9 +75,11 @@ namespace io.harness.cfsdk.client.dto
 
         public override string ToString()
         {
+#pragma warning disable CS0618 // Suppress warnings for using obsolete properties
             var attributesStr = string.Join(", ", Attributes.Select(kv => $"{kv.Key}: {(IsPrivate && PrivateAttributes.Contains(kv.Key) ? "Private" : kv.Value)}"));
             var privateAttributesStr = IsPrivate ? $"Private Attributes: {string.Join(", ", PrivateAttributes)}" : string.Empty;
             return $"Identifier: {Identifier}, Name: {Name}, Attributes: {attributesStr}, IsPrivate: {IsPrivate}, {privateAttributesStr}".TrimEnd(',', ' ');
+#pragma warning restore CS0618 // Restore warnings for using obsolete properties
         }
 
 
@@ -175,7 +177,9 @@ namespace io.harness.cfsdk.client.dto
 
         public Target build()
         {
+#pragma warning disable CS0618 // Suppress warnings for using obsolete constructor
             return new Target(identifier, name, attributes, isPrivate, privateAttributes);
+#pragma warning restore CS0618 // Restore warnings
         }
     }
 }

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -8,10 +8,10 @@
         <PackageId>ff-dotnet-server-sdk</PackageId>
         <RootNamespace>io.harness.cfsdk</RootNamespace>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.7.6</Version>
+        <Version>1.8.0</Version>
         <PackOnBuild>true</PackOnBuild>
-        <PackageVersion>1.7.6</PackageVersion>
-        <AssemblyVersion>1.7.6</AssemblyVersion>
+        <PackageVersion>$(Version)</PackageVersion>
+        <AssemblyVersion>$(Version)</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2026</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -14,8 +14,6 @@
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2026</Copyright>
-        <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -35,7 +33,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="LICENSE" Pack="true" PackagePath="\" />
         <None Include="README.md" Pack="true" PackagePath="\" />
 
         <Compile Remove="tests\**;examples\**;tools\**" />

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -27,6 +27,11 @@
         <PackageReleaseNotes>.NET Server SDK for Harness Feature Flag platform</PackageReleaseNotes>
         <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+        <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -15,6 +15,8 @@
         <Authors>support@harness.io</Authors>
         <Copyright>Copyright © 2026</Copyright>
         <PackageIconUrl>https://harness.io/icon-ff.svg</PackageIconUrl>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageProjectUrl>https://github.com/drone/ff-dotnet-server-sdk</PackageProjectUrl>
@@ -28,6 +30,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <None Include="LICENSE" Pack="true" PackagePath="\" />
+        <None Include="README.md" Pack="true" PackagePath="\" />
+
         <Compile Remove="tests\**;examples\**;tools\**" />
         <EmbeddedResource Remove="tests\**;examples\**;tools\**" />
         <None Remove="tests\**;examples\**;tools\**" />

--- a/tests/ff-server-sdk-test/api/CfClientTest.cs
+++ b/tests/ff-server-sdk-test/api/CfClientTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using io.harness.cfsdk.client.api;
 using io.harness.cfsdk.client.dto;
 using WireMock.RequestBuilders;
@@ -8,7 +9,6 @@ using WireMock.ResponseBuilders;
 using WireMock.Server;
 using WireMock.Settings;
 using NUnit.Framework;
-using WireMock;
 using WireMock.Logging;
 
 
@@ -93,7 +93,7 @@ namespace ff_server_sdk_test.api
 
 
         [Test]
-        public void PerformanceTestInClauseWithManyValues()
+        public async Task PerformanceTestInClauseWithManyValues()
         {
             server
                 .Given(Request.Create().WithPath("/api/1.0/client/auth").UsingPost())
@@ -104,7 +104,7 @@ namespace ff_server_sdk_test.api
                     .WithPath("/api/1.0/client/env/00000000-0000-0000-0000-000000000000/feature-configs").UsingGet())
                 .RespondWith(Response.Create()
                     .WithStatusCode(200)
-                    .WithBody(MakeFeatureConfigBody(MakeVariationMap( "inRule", "on"))));
+                    .WithBody(MakeFeatureConfigBody(MakeVariationMap("inRule", "on"))));
 
             server
                 .Given(Request.Create()
@@ -146,10 +146,13 @@ namespace ff_server_sdk_test.api
 
             var result = client.boolVariation("Feature", target, false);
             Assert.That(result, Is.EqualTo(true), "did not get correct flag state");
+
+            result = await client.boolVariationAsync("Feature", target, false);
+            Assert.That(result, Is.EqualTo(true), "did not get correct flag state");
         }
 
         [Test]
-        public void ShouldNotThrowErrorIfTargetToVariationMapNotPopulated()
+        public async Task ShouldNotThrowErrorIfTargetToVariationMapNotPopulated()
         {
             server
                 .Given(Request.Create().WithPath("/api/1.0/client/auth").UsingPost())
@@ -200,6 +203,9 @@ namespace ff_server_sdk_test.api
             Assert.That(ok, Is.True, "failed to init in time");
 
             var result = client.stringVariation("FeatureWithVariationToTargetMapSetAsNull", target, "failed");
+            Assert.That(result, Is.EqualTo("on"), "did not get correct flag state");
+
+            result = await client.stringVariationAsync("FeatureWithVariationToTargetMapSetAsNull", target, "failed");
             Assert.That(result, Is.EqualTo("on"), "did not get correct flag state");
         }
 


### PR DESCRIPTION
# Overview

This pull request updates the `ICfClient`, `InnerClient`, `IEvaluator`, and `IPollingProcessor` to use proper .NET `async`/`await` Tasks throughout the call stack. The original synchronous methods now call the `XxxAsync()` counterpart using `.GetAwaiter().GetResult()`. This provides multiple benefits: a) the main thread is not halted and waiting for the retrieval to finish, freeing up the thread to be used for other actions; b) the call stack and thrown exceptions are as if it were a normal call, allowing for better debugging should issues arise.

This also fixes a logic issue in the `EventSource` streaming logic to ensure an exception is not thrown when the service is not available.

Finally, this updates the package versioning to use `VersionPrefix` so preview packages can be created and published.

# Testing

I was able to verify that this logic, both synchronous and asynchronous, works as expected. I ran through the main exposed `CfClient` calls and they returned the expected values with no issues.

> [!NOTE]
> For all intents and purposes this should be backward compatible for the existing synchronous calls. There _may_ be differences for those implementations where they were expecting an `AggregateException` and having to parse through the `InnerException` collection.